### PR TITLE
Handle IMAP UID range gaps and pdf2json failures during email ingestion

### DIFF
--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
@@ -193,8 +193,15 @@ export class ImapConnector implements IEmailConnector {
                                 this.newMaxUids[mailboxPath] = msg.uid;
                             }
 
+                            logger.debug({ mailboxPath, uid: msg.uid }, 'Processing message');
+
                             if (msg.envelope && msg.source) {
-                                yield await this.parseMessage(msg, mailboxPath);
+                                try {
+                                    yield await this.parseMessage(msg, mailboxPath);
+                                } catch (err: any) {
+                                    logger.error({ err, mailboxPath, uid: msg.uid }, 'Failed to parse message');
+                                    throw err;
+                                }
                             }
                         }
 


### PR DESCRIPTION
- Avoid hanging when pdf2json fails by resolving text extraction with an empty string