### PR TITLE
Fix Graph delta query: exclude unsupported @removed field

### DIFF
--- a/packages/backend/src/services/ingestion-connectors/MicrosoftConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/MicrosoftConnector.ts
@@ -230,7 +230,7 @@ export class MicrosoftConnector implements IEmailConnector {
 			try {
 				const response = await this.graphClient
 					.api(requestUrl)
-					.select('id,conversationId,@removed')
+					.select('id,conversationId')
 					.get();
 
 				for (const message of response.value) {


### PR DESCRIPTION
# Fix Graph delta query: exclude unsupported @removed field

## Summary
This pull request resolves #44  by adjusting the Microsoft Graph delta query to remove the unsupported `@removed` field. The query now selects only `id` and `conversationId`, while removed messages are still correctly skipped during iteration.

## Changes
- Removed `@removed` field from the delta query (unsupported by Graph)
- Limited selection to `id` and `conversationId`
- Kept logic for skipping removed messages during iteration

## Benefits
- Prevents runtime errors due to unsupported field
- Keeps implementation aligned with Graph API best practices