### PR TITLE
fix: missing path separator for non-ASCII IMAP folder names

### DIFF
--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -575,7 +575,7 @@ export class IngestionService {
 				return null;
 			}
 
-			const sanitizedPath = email.path ? email.path : '';
+			const sanitizedPath = email.path ? email.path.replace(/\/?$/, '/') : '';
 			// Use effectiveSource (root) for storage path and DB ownership.
 			// Child sources are assistants; all content physically belongs to the root.
 			const emailPath = `${config.storage.openArchiverFolderName}/${effectiveSource.name.replaceAll(' ', '-')}-${effectiveSource.id}/emails/${sanitizedPath}${email.id}.eml`;


### PR DESCRIPTION
Emails in non-ASCII folders  were stored as `folder_nameID.eml` instead of `folder_name/ID.eml` — folder name and message ID got merged together.

Fixed by adding a trailing slash to `sanitizedPath` in `IngestionService`.

>Note: the filename encoding fix for downloads is covered by #348 and #181.