### PR TITLE
fix: use correct default Redis/Valkey username in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,8 @@ REDIS_PORT=6379
 REDIS_PASSWORD=defaultredispassword
 # If you run Valkey service from Docker Compose, set the REDIS_TLS_ENABLED variable to false.
 REDIS_TLS_ENABLED=false
-# Redis username. Only required if not using the default user.
-REDIS_USER=notdefaultuser
+# Redis/Valkey username. Leave as 'default' unless you have configured a custom ACL user.
+REDIS_USER=default
 
 
 # --- Storage Settings ---


### PR DESCRIPTION
## Summary

* The `docker-compose.yml` starts Valkey with `--requirepass` only (no custom ACL user), so the only valid username is `default`
* `.env.example` shipped `REDIS_USER=notdefaultuser` which does not exist, causing a `WRONGPASS` error on every fresh install

Fixes #347