### PR TITLE
Switch deployment flow from git clone to compose.yaml download

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,7 +38,7 @@ Thumbs.db
 *.sw?
 
 # Docker
-docker-compose.yml
+compose.yaml
 .dockerignore
 Dockerfile
 

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ ALL_INCLUSIVE_ARCHIVE=false
 INGESTION_WORKER_CONCURRENCY=5
 
 # --- Docker Compose Service Configuration ---
-# These variables are used by docker-compose.yml to configure the services. Leave them unchanged if you use Docker services for Postgresql, Valkey (Redis) and Meilisearch. If you decide to use your own instances of these services, you can substitute them with your own connection credentials.
+# These variables are used by compose.yaml to configure the services. Leave them unchanged if you use Docker services for Postgresql, Valkey (Redis) and Meilisearch. If you decide to use your own instances of these services, you can substitute them with your own connection credentials.
 
 # PostgreSQL
 POSTGRES_DB=open_archive
@@ -119,7 +119,7 @@ RETENTION_BATCH_SIZE=1000
 # --- SMTP Journaling (Enterprise only) ---
 # The port the embedded SMTP journaling listener binds to inside the container.
 # This is the port your MTA (Exchange, MS365, Postfix, etc.) will send journal reports to.
-# The docker-compose.yml maps this same port on the host side by default.
+# The compose.yaml maps this same port on the host side by default.
 SMTP_JOURNALING_PORT=2525
 # The domain used to generate routing addresses for journaling sources.
 # Each source gets a unique address like journal-<id>@<domain>.

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ INGESTION_WORKER_CONCURRENCY=5
 INGESTION_EMAIL_CONCURRENCY=3
 
 # --- Docker Compose Service Configuration ---
-# These variables are used by docker-compose.yml to configure the services. Leave them unchanged if you use Docker services for Postgresql, Valkey (Redis) and Meilisearch. If you decide to use your own instances of these services, you can substitute them with your own connection credentials.
+# These variables are used by compose.yaml to configure the services. Leave them unchanged if you use Docker services for Postgresql, Valkey (Redis) and Meilisearch. If you decide to use your own instances of these services, you can substitute them with your own connection credentials.
 
 # PostgreSQL
 POSTGRES_DB=open_archive
@@ -67,7 +67,7 @@ REDIS_PASSWORD=defaultredispassword
 # If you run Valkey service from Docker Compose, set the REDIS_TLS_ENABLED variable to false.
 REDIS_TLS_ENABLED=false
 # Redis username. Only needed when your Redis/Valkey has ACL users configured.
-# The Valkey service in docker-compose.yml runs with --requirepass only, and on such a
+# The Valkey service in compose.yaml runs with --requirepass only, and on such a
 # server the single user is 'default', so naming any other user fails every connection
 # with "WRONGPASS invalid username-password pair". Leave this unset for the default setup.
 # REDIS_USER=default
@@ -158,7 +158,7 @@ RETENTION_BATCH_SIZE=1000
 # --- SMTP Journaling (Enterprise only) ---
 # The port the embedded SMTP journaling listener binds to inside the container.
 # This is the port your MTA (Exchange, MS365, Postfix, etc.) will send journal reports to.
-# The docker-compose.yml maps this same port on the host side by default.
+# The compose.yaml maps this same port on the host side by default.
 SMTP_JOURNALING_PORT=2525
 # The domain used to generate routing addresses for journaling sources.
 # Each source gets a unique address like journal-<id>@<domain>.

--- a/README.md
+++ b/README.md
@@ -77,21 +77,21 @@ Open Archiver is built on a modern, scalable, and maintainable technology stack:
 
 ### Installation
 
-1.  **Clone the repository:**
+1.  **Download the deployment files:**
+
+    Create a directory for your deployment and fetch the Compose file and the example environment file:
 
     ```bash
-    git clone https://github.com/LogicLabs-OU/OpenArchiver.git
-    cd OpenArchiver
+    mkdir open-archiver && cd open-archiver
+    curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+    curl -L -o .env https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/.env.example
     ```
+
+    The Open Archiver image is self-contained, so the source repository does not need to be cloned to run the application.
 
 2.  **Configure your environment:**
-    Copy the example environment file and customize it with your settings.
 
-    ```bash
-    cp .env.example .env
-    ```
-
-    You will need to edit the `.env` file to set your admin passwords, secret keys, and other essential configuration. Read the .env.example for how to set up.
+    Open the `.env` file in a text editor and set your admin passwords, secret keys, and other essential configuration. The file is heavily commented; read it for the meaning of each variable.
 
 3.  **Run the application:**
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     open-archiver:
         image: logiclabshq/open-archiver:latest

--- a/docs/enterprise/journaling/guide.md
+++ b/docs/enterprise/journaling/guide.md
@@ -18,13 +18,13 @@ Add the following to your `.env` file:
 
 | Variable                               | Default     | Description                                                                                                                                                    |
 | -------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SMTP_JOURNALING_PORT`                 | `2525`      | The port the SMTP listener binds to inside the container. The `docker-compose.yml` maps this to the host.                                                      |
+| `SMTP_JOURNALING_PORT`                 | `2525`      | The port the SMTP listener binds to inside the container. The `compose.yaml` maps this to the host.                                                            |
 | `SMTP_JOURNALING_DOMAIN`               | `localhost` | The domain used to generate routing addresses (e.g., `journal-abc12345@journal.yourdomain.com`). Set this to the domain whose MX record points to this server. |
 | `JOURNAL_QUEUE_BACKPRESSURE_THRESHOLD` | `10000`     | Maximum waiting jobs before the listener returns 4xx temporary failures.                                                                                       |
 
 ## Docker Deployment
 
-The `docker-compose.yml` exposes the SMTP port on the host:
+The `compose.yaml` exposes the SMTP port on the host:
 
 ```yaml
 ports:

--- a/docs/user-guides/email-providers/eml.md
+++ b/docs/user-guides/email-providers/eml.md
@@ -37,7 +37,7 @@ archive.zip
     > **Note on Local Path:** When using Docker, the "Local Path" is relative to the container's filesystem.
     >
     > - **Recommended:** Place your zip file in a `temp` folder inside your configured storage directory (`STORAGE_LOCAL_ROOT_PATH`). This path is already mounted. For example, if your storage path is `/data`, put the file in `/data/temp/emails.zip` and enter `/data/temp/emails.zip` as the path.
-    > - **Alternative:** Mount a separate volume in `docker-compose.yml` (e.g., `- /host/path:/container/path`) and use the container path.
+    > - **Alternative:** Mount a separate volume in `compose.yaml` (e.g., `- /host/path:/container/path`) and use the container path.
 
 6.  Click the **Submit** button.
 

--- a/docs/user-guides/email-providers/mbox.md
+++ b/docs/user-guides/email-providers/mbox.md
@@ -24,7 +24,7 @@ Once you have your `.mbox` file, you can upload it to OpenArchiver through the w
     > **Note on Local Path:** When using Docker, the "Local Path" is relative to the container's filesystem.
     >
     > - **Recommended:** Place your mbox file in a `temp` folder inside your configured storage directory (`STORAGE_LOCAL_ROOT_PATH`). This path is already mounted. For example, if your storage path is `/data`, put the file in `/data/temp/emails.mbox` and enter `/data/temp/emails.mbox` as the path.
-    > - **Alternative:** Mount a separate volume in `docker-compose.yml` (e.g., `- /host/path:/container/path`) and use the container path.
+    > - **Alternative:** Mount a separate volume in `compose.yaml` (e.g., `- /host/path:/container/path`) and use the container path.
 
 ## 3. Folder Structure
 

--- a/docs/user-guides/email-providers/mbox.md
+++ b/docs/user-guides/email-providers/mbox.md
@@ -24,7 +24,7 @@ Once you have your `.mbox` file, you can upload it to OpenArchiver through the w
     > **Note on Local Path:** When using Docker, the "Local Path" is relative to the container's filesystem.
     >
     > - **Recommended:** Place your mbox file in a `temp` folder inside your configured storage directory (`STORAGE_LOCAL_ROOT_PATH`). This path is already mounted. For example, if your storage path is `/data`, put the file in `/data/temp/emails.mbox` and enter `/data/temp/emails.mbox` as the path.
-    > - **Alternative:** Mount a separate volume in `docker-compose.yml` (e.g., `- /host/path:/container/path`) and use the container path.
+    > - **Alternative:** Mount a separate volume in `compose.yaml` (e.g., `- /host/path:/container/path`) and use the container path.
 
 > **Upload feedback:** When you use the **Upload File** method, a progress bar shows the upload percentage while the file transfers, and a **Cancel** button lets you stop an in-progress upload. Once the upload finishes, a success panel confirms the stored file name and its path; if the upload fails, an error panel shows the reason so you can fix it and try again.
 

--- a/docs/user-guides/email-providers/pst.md
+++ b/docs/user-guides/email-providers/pst.md
@@ -22,7 +22,7 @@ To ensure a successful import, you should prepare your PST file according to the
     > **Note on Local Path:** When using Docker, the "Local Path" is relative to the container's filesystem.
     >
     > - **Recommended:** Place your file in a `temp` folder inside your configured storage directory (`STORAGE_LOCAL_ROOT_PATH`). This path is already mounted. For example, if your storage path is `/data`, put the file in `/data/temp/archive.pst` and enter `/data/temp/archive.pst` as the path.
-    > - **Alternative:** Mount a separate volume in `docker-compose.yml` (e.g., `- /host/path:/container/path`) and use the container path.
+    > - **Alternative:** Mount a separate volume in `compose.yaml` (e.g., `- /host/path:/container/path`) and use the container path.
 
 6.  Click the **Submit** button.
 

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -75,12 +75,12 @@ If you want to use S3-compatible object storage, change the `STORAGE_TYPE` to `s
 
 ### Using External Services
 
-For convenience, the `docker-compose.yml` file includes services for PostgreSQL, Valkey (Redis), and Meilisearch. However, you can use your own external or managed instances for these services.
+For convenience, the `compose.yaml` file includes services for PostgreSQL, Valkey (Redis), and Meilisearch. However, you can use your own external or managed instances for these services.
 
 To do so:
 
 1.  **Update your `.env` file**: Change the host, port, and credential variables to point to your external service instances. For example, you would update `DATABASE_URL`, `REDIS_HOST`, and `MEILI_HOST`.
-2.  **Modify `docker-compose.yml`**: Remove or comment out the service definitions for `postgres`, `valkey`, and `meilisearch` from your `docker-compose.yml` file.
+2.  **Modify `compose.yaml`**: Remove or comment out the service definitions for `postgres`, `valkey`, and `meilisearch` from your `compose.yaml` file.
 
 This will configure the Open Archiver application to connect to your services instead of starting the default ones.
 
@@ -102,7 +102,7 @@ Here is a complete list of environment variables available for configuration:
 
 #### Docker Compose Service Configuration
 
-These variables are used by `docker-compose.yml` to configure the services.
+These variables are used by `compose.yaml` to configure the services.
 
 | Variable               | Description                                          | Default Value                                            |
 | ---------------------- | ---------------------------------------------------- | -------------------------------------------------------- |
@@ -207,11 +207,11 @@ docker compose up -d
 
 If you are deploying Open Archiver on [Coolify](https://coolify.io/), it is recommended to let Coolify manage the Docker networks for you. This can help avoid potential routing conflicts and simplify your setup.
 
-To do this, you will need to make a small modification to your `docker-compose.yml` file.
+To do this, you will need to make a small modification to your `compose.yaml` file.
 
-### Modify `docker-compose.yml` for Coolify
+### Modify `compose.yaml` for Coolify
 
-1.  **Open your `docker-compose.yml` file** in a text editor.
+1.  **Open your `compose.yaml` file** in a text editor.
 
 2.  **Remove all `networks` sections** from the file. This includes the network configuration for each service and the top-level network definition.
 
@@ -238,7 +238,7 @@ To do this, you will need to make a small modification to your `docker-compose.y
     -     driver: bridge
     ```
 
-3.  **Save the modified `docker-compose.yml` file.**
+3.  **Save the modified `compose.yaml` file.**
 
 By removing these sections, you allow Coolify to automatically create and manage the necessary networks, ensuring that all services can communicate with each other and are correctly exposed through Coolify's reverse proxy.
 
@@ -246,7 +246,7 @@ After making these changes, you can proceed with deploying your application on C
 
 ## Where is my data stored (When using local storage and Docker)?
 
-If you are using local storage to store your emails, based on your `docker-compose.yml` file, your data is being stored in what's called a "named volume" (`archiver-data`). That's why you're not seeing the files in the `./data/open-archiver` directory you created.
+If you are using local storage to store your emails, based on your `compose.yaml` file, your data is being stored in what's called a "named volume" (`archiver-data`). That's why you're not seeing the files in the `./data/open-archiver` directory you created.
 
 1.  **List all Docker volumes**:
 
@@ -291,13 +291,13 @@ In this example, the data is located at `/var/lib/docker/volumes/us8wwos0o4ok4go
 
 ### To save data to a specific folder
 
-To save the data to a specific folder on your machine, you'll need to make a change to your `docker-compose.yml`. You need to switch from a named volume to a "bind mount".
+To save the data to a specific folder on your machine, you'll need to make a change to your `compose.yaml`. You need to switch from a named volume to a "bind mount".
 
 Here’s how you can do it:
 
-1.  **Edit `docker-compose.yml`**:
+1.  **Edit `compose.yaml`**:
 
-Open the `docker-compose.yml` file and find the `open-archiver` service. You're going to change the `volumes` section.
+Open the `compose.yaml` file and find the `open-archiver` service. You're going to change the `volumes` section.
 
 **Change this:**
 
@@ -335,7 +335,7 @@ volumes:
 After you've saved the changes, run the following command in your terminal to apply them. The `--force-recreate` flag will ensure the container is recreated with the new volume settings.
 
 ```bash
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 After this, any new data will be saved directly into the `./data/open-archiver` folder in your project directory.

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -6,15 +6,17 @@ This guide will walk you through setting up Open Archiver using Docker Compose. 
 
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your server or local machine.
 - A server or local machine with at least 4GB of RAM (2GB of RAM if you use external Postgres, Redis (Valkey) and Meilisearch instances).
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed on your server or local machine.
 
-## 1. Clone the Repository
+## 1. Download the Deployment Files
 
-First, clone the Open Archiver repository to your machine:
+The Open Archiver image is self-contained, so you do not need to clone the source repository to run the application. You only need two files: the Compose file and the example environment file.
+
+Create a directory for your deployment and download both files:
 
 ```bash
-git clone https://github.com/LogicLabs-OU/OpenArchiver.git
-cd OpenArchiver
+mkdir open-archiver && cd open-archiver
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+curl -L -o .env https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/.env.example
 ```
 
 ## 2. Create a Directory for Local Storage (Important)
@@ -34,15 +36,9 @@ This ensures the directory is owned by your current user, which is necessary for
 
 ## 3. Configure Your Environment
 
-The application is configured using environment variables. You'll need to create a `.env` file to store your configuration.
+The application is configured using environment variables. The `.env` file you downloaded in step 1 contains the example configuration.
 
-Copy the example environment file for Docker:
-
-```bash
-cp .env.example.docker .env
-```
-
-Now, open the `.env` file in a text editor and customize the settings.
+Open the `.env` file in a text editor and customize the settings.
 
 ### Key Configuration Steps
 
@@ -190,18 +186,23 @@ After successfully deploying and logging into Open Archiver, the next step is to
 
 ## Updating Your Installation
 
-To update your Open Archiver instance to the latest version, run the following commands:
+To update your Open Archiver instance to the latest version, pull the new images and restart the services from your deployment directory:
 
 ```bash
-# Pull the latest changes from the repository
-git pull
-
 # Pull the latest Docker images
 docker compose pull
 
 # Restart the services with the new images
 docker compose up -d
 ```
+
+If a release announces changes to `compose.yaml` itself (for example a new service or a renamed volume), re-download it before restarting:
+
+```bash
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+```
+
+The release notes will call this out explicitly when it is needed.
 
 ## Deploying on Coolify
 

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -77,12 +77,12 @@ If you want to use S3-compatible object storage, change the `STORAGE_TYPE` to `s
 
 ### Using External Services
 
-For convenience, the `docker-compose.yml` file includes services for PostgreSQL, Valkey (Redis), and Meilisearch. However, you can use your own external or managed instances for these services.
+For convenience, the `compose.yaml` file includes services for PostgreSQL, Valkey (Redis), and Meilisearch. However, you can use your own external or managed instances for these services.
 
 To do so:
 
 1.  **Update your `.env` file**: Change the host, port, and credential variables to point to your external service instances. For example, you would update `DATABASE_URL`, `REDIS_HOST`, and `MEILI_HOST`.
-2.  **Modify `docker-compose.yml`**: Remove or comment out the service definitions for `postgres`, `valkey`, and `meilisearch` from your `docker-compose.yml` file.
+2.  **Modify `compose.yaml`**: Remove or comment out the service definitions for `postgres`, `valkey`, and `meilisearch` from your `compose.yaml` file.
 
 This will configure the Open Archiver application to connect to your services instead of starting the default ones.
 
@@ -106,7 +106,7 @@ Here is a complete list of environment variables available for configuration:
 
 #### Docker Compose Service Configuration
 
-These variables are used by `docker-compose.yml` to configure the services.
+These variables are used by `compose.yaml` to configure the services.
 
 | Variable               | Description                                          | Default Value                                            |
 | ---------------------- | ---------------------------------------------------- | -------------------------------------------------------- |
@@ -178,7 +178,7 @@ These variables are used by `docker-compose.yml` to configure the services.
 
 | Variable                               | Description                                                                                                                                                                                                                        | Default Value            |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `SMTP_JOURNALING_PORT`                 | The port the embedded SMTP journaling listener binds to inside the container. Your MTA must be configured to deliver journal reports to this port. The `docker-compose.yml` file maps this port to the 25 host.                    | `2525`                   |
+| `SMTP_JOURNALING_PORT`                 | The port the embedded SMTP journaling listener binds to inside the container. Your MTA must be configured to deliver journal reports to this port. The `compose.yaml` file maps this port to the 25 host.                          | `2525`                   |
 | `SMTP_JOURNALING_DOMAIN`               | The domain used to generate unique routing addresses for each journaling source (e.g., `journal-abc12345@<domain>`). Set this to the domain or subdomain whose MX record points to your Open Archiver server.                      | `journal.yourdomain.com` |
 | `JOURNAL_QUEUE_BACKPRESSURE_THRESHOLD` | The maximum number of waiting jobs in the journal inbound queue before the SMTP listener starts returning `4xx` temporary failures. The MTA will automatically retry. This prevents unbounded queue growth if workers fall behind. | `10000`                  |
 | `JOURNAL_WORKER_CONCURRENCY`           | The number of journaling worker threads that process inbound journal emails concurrently. Increase on servers with more CPU cores to handle high-volume journaling deployments.                                                    | `3`                      |
@@ -242,11 +242,11 @@ docker compose up -d
 
 If you are deploying Open Archiver on [Coolify](https://coolify.io/), it is recommended to let Coolify manage the Docker networks for you. This can help avoid potential routing conflicts and simplify your setup.
 
-To do this, you will need to make a small modification to your `docker-compose.yml` file.
+To do this, you will need to make a small modification to your `compose.yaml` file.
 
-### Modify `docker-compose.yml` for Coolify
+### Modify `compose.yaml` for Coolify
 
-1.  **Open your `docker-compose.yml` file** in a text editor.
+1.  **Open your `compose.yaml` file** in a text editor.
 
 2.  **Remove all `networks` sections** from the file. This includes the network configuration for each service and the top-level network definition.
 
@@ -273,7 +273,7 @@ To do this, you will need to make a small modification to your `docker-compose.y
     -     driver: bridge
     ```
 
-3.  **Save the modified `docker-compose.yml` file.**
+3.  **Save the modified `compose.yaml` file.**
 
 By removing these sections, you allow Coolify to automatically create and manage the necessary networks, ensuring that all services can communicate with each other and are correctly exposed through Coolify's reverse proxy.
 
@@ -281,7 +281,7 @@ After making these changes, you can proceed with deploying your application on C
 
 ## Where is my data stored (When using local storage and Docker)?
 
-If you are using local storage to store your emails, based on your `docker-compose.yml` file, your data is being stored in what's called a "named volume" (`archiver-data`). That's why you're not seeing the files in the `./data/open-archiver` directory you created.
+If you are using local storage to store your emails, based on your `compose.yaml` file, your data is being stored in what's called a "named volume" (`archiver-data`). That's why you're not seeing the files in the `./data/open-archiver` directory you created.
 
 1.  **List all Docker volumes**:
 
@@ -326,13 +326,13 @@ In this example, the data is located at `/var/lib/docker/volumes/us8wwos0o4ok4go
 
 ### To save data to a specific folder
 
-To save the data to a specific folder on your machine, you'll need to make a change to your `docker-compose.yml`. You need to switch from a named volume to a "bind mount".
+To save the data to a specific folder on your machine, you'll need to make a change to your `compose.yaml`. You need to switch from a named volume to a "bind mount".
 
 Here’s how you can do it:
 
-1.  **Edit `docker-compose.yml`**:
+1.  **Edit `compose.yaml`**:
 
-Open the `docker-compose.yml` file and find the `open-archiver` service. You're going to change the `volumes` section.
+Open the `compose.yaml` file and find the `open-archiver` service. You're going to change the `volumes` section.
 
 **Change this:**
 
@@ -370,7 +370,7 @@ volumes:
 After you've saved the changes, run the following command in your terminal to apply them. The `--force-recreate` flag will ensure the container is recreated with the new volume settings.
 
 ```bash
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 After this, any new data will be saved directly into the `./data/open-archiver` folder in your project directory.

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -6,15 +6,17 @@ This guide will walk you through setting up Open Archiver using Docker Compose. 
 
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your server or local machine.
 - A server or local machine with at least 4GB of RAM (2GB of RAM if you use external Postgres, Redis (Valkey) and Meilisearch instances).
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed on your server or local machine.
 
-## 1. Clone the Repository
+## 1. Download the Deployment Files
 
-First, clone the Open Archiver repository to your machine:
+The Open Archiver image is self-contained, so you do not need to clone the source repository to run the application. You only need two files: the Compose file and the example environment file.
+
+Create a directory for your deployment and download both files:
 
 ```bash
-git clone https://github.com/LogicLabs-OU/OpenArchiver.git
-cd OpenArchiver
+mkdir open-archiver && cd open-archiver
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+curl -L -o .env https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/.env.example
 ```
 
 ## 2. Create a Directory for Local Storage
@@ -36,15 +38,9 @@ This ensures the directory is owned by your current user, which is necessary for
 
 ## 3. Configure Your Environment
 
-The application is configured using environment variables. You'll need to create a `.env` file to store your configuration.
+The application is configured using environment variables. The `.env` file you downloaded in step 1 contains the example configuration.
 
-Copy the example environment file for Docker:
-
-```bash
-cp .env.example.docker .env
-```
-
-Now, open the `.env` file in a text editor and customize the settings.
+Open the `.env` file in a text editor and customize the settings.
 
 ### Key Configuration Steps
 
@@ -225,18 +221,23 @@ After successfully deploying and logging into Open Archiver, the next step is to
 
 ## Updating Your Installation
 
-To update your Open Archiver instance to the latest version, run the following commands:
+To update your Open Archiver instance to the latest version, pull the new images and restart the services from your deployment directory:
 
 ```bash
-# Pull the latest changes from the repository
-git pull
-
 # Pull the latest Docker images
 docker compose pull
 
 # Restart the services with the new images
 docker compose up -d
 ```
+
+If a release announces changes to `compose.yaml` itself (for example a new service or a renamed volume), re-download it before restarting:
+
+```bash
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+```
+
+The release notes will call this out explicitly when it is needed.
 
 ## Deploying on Coolify
 

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -77,12 +77,12 @@ If you want to use S3-compatible object storage, change the `STORAGE_TYPE` to `s
 
 ### Using External Services
 
-For convenience, the `docker-compose.yml` file includes services for PostgreSQL, Valkey (Redis), and Meilisearch. However, you can use your own external or managed instances for these services.
+For convenience, the `compose.yaml` file includes services for PostgreSQL, Valkey (Redis), and Meilisearch. However, you can use your own external or managed instances for these services.
 
 To do so:
 
 1.  **Update your `.env` file**: Change the host, port, and credential variables to point to your external service instances. For example, you would update `DATABASE_URL`, `REDIS_HOST`, and `MEILI_HOST`.
-2.  **Modify `docker-compose.yml`**: Remove or comment out the service definitions for `postgres`, `valkey`, and `meilisearch` from your `docker-compose.yml` file.
+2.  **Modify `compose.yaml`**: Remove or comment out the service definitions for `postgres`, `valkey`, and `meilisearch` from your `compose.yaml` file.
 
 This will configure the Open Archiver application to connect to your services instead of starting the default ones.
 
@@ -108,7 +108,7 @@ Here is a complete list of environment variables available for configuration:
 
 #### Docker Compose Service Configuration
 
-These variables are used by `docker-compose.yml` to configure the services.
+These variables are used by `compose.yaml` to configure the services.
 
 | Variable                           | Description                                                                                              | Default Value                                            |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
@@ -183,7 +183,7 @@ These variables are used by `docker-compose.yml` to configure the services.
 
 | Variable                               | Description                                                                                                                                                                                                                        | Default Value            |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `SMTP_JOURNALING_PORT`                 | The port the embedded SMTP journaling listener binds to inside the container. Your MTA must be configured to deliver journal reports to this port. The `docker-compose.yml` file maps this port to the 25 host.                    | `2525`                   |
+| `SMTP_JOURNALING_PORT`                 | The port the embedded SMTP journaling listener binds to inside the container. Your MTA must be configured to deliver journal reports to this port. The `compose.yaml` file maps this port to the 25 host.                          | `2525`                   |
 | `SMTP_JOURNALING_DOMAIN`               | The domain used to generate unique routing addresses for each journaling source (e.g., `journal-abc12345@<domain>`). Set this to the domain or subdomain whose MX record points to your Open Archiver server.                      | `journal.yourdomain.com` |
 | `JOURNAL_QUEUE_BACKPRESSURE_THRESHOLD` | The maximum number of waiting jobs in the journal inbound queue before the SMTP listener starts returning `4xx` temporary failures. The MTA will automatically retry. This prevents unbounded queue growth if workers fall behind. | `10000`                  |
 | `JOURNAL_WORKER_CONCURRENCY`           | The number of journaling worker threads that process inbound journal emails concurrently. Increase on servers with more CPU cores to handle high-volume journaling deployments.                                                    | `3`                      |
@@ -247,11 +247,11 @@ docker compose up -d
 
 If you are deploying Open Archiver on [Coolify](https://coolify.io/), it is recommended to let Coolify manage the Docker networks for you. This can help avoid potential routing conflicts and simplify your setup.
 
-To do this, you will need to make a small modification to your `docker-compose.yml` file.
+To do this, you will need to make a small modification to your `compose.yaml` file.
 
-### Modify `docker-compose.yml` for Coolify
+### Modify `compose.yaml` for Coolify
 
-1.  **Open your `docker-compose.yml` file** in a text editor.
+1.  **Open your `compose.yaml` file** in a text editor.
 
 2.  **Remove all `networks` sections** from the file. This includes the network configuration for each service and the top-level network definition.
 
@@ -278,7 +278,7 @@ To do this, you will need to make a small modification to your `docker-compose.y
     -     driver: bridge
     ```
 
-3.  **Save the modified `docker-compose.yml` file.**
+3.  **Save the modified `compose.yaml` file.**
 
 By removing these sections, you allow Coolify to automatically create and manage the necessary networks, ensuring that all services can communicate with each other and are correctly exposed through Coolify's reverse proxy.
 
@@ -286,7 +286,7 @@ After making these changes, you can proceed with deploying your application on C
 
 ## Where is my data stored (When using local storage and Docker)?
 
-If you are using local storage to store your emails, based on your `docker-compose.yml` file, your data is being stored in what's called a "named volume" (`archiver-data`). That's why you're not seeing the files in the `./data/open-archiver` directory you created.
+If you are using local storage to store your emails, based on your `compose.yaml` file, your data is being stored in what's called a "named volume" (`archiver-data`). That's why you're not seeing the files in the `./data/open-archiver` directory you created.
 
 1.  **List all Docker volumes**:
 
@@ -331,13 +331,13 @@ In this example, the data is located at `/var/lib/docker/volumes/us8wwos0o4ok4go
 
 ### To save data to a specific folder
 
-To save the data to a specific folder on your machine, you'll need to make a change to your `docker-compose.yml`. You need to switch from a named volume to a "bind mount".
+To save the data to a specific folder on your machine, you'll need to make a change to your `compose.yaml`. You need to switch from a named volume to a "bind mount".
 
 Here’s how you can do it:
 
-1.  **Edit `docker-compose.yml`**:
+1.  **Edit `compose.yaml`**:
 
-Open the `docker-compose.yml` file and find the `open-archiver` service. You're going to change the `volumes` section.
+Open the `compose.yaml` file and find the `open-archiver` service. You're going to change the `volumes` section.
 
 **Change this:**
 
@@ -375,7 +375,7 @@ volumes:
 After you've saved the changes, run the following command in your terminal to apply them. The `--force-recreate` flag will ensure the container is recreated with the new volume settings.
 
 ```bash
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 After this, any new data will be saved directly into the `./data/open-archiver` folder in your project directory.

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -6,15 +6,17 @@ This guide will walk you through setting up Open Archiver using Docker Compose. 
 
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your server or local machine.
 - A server or local machine with at least 4GB of RAM (2GB of RAM if you use external Postgres, Redis (Valkey) and Meilisearch instances).
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed on your server or local machine.
 
-## 1. Clone the Repository
+## 1. Download the Deployment Files
 
-First, clone the Open Archiver repository to your machine:
+The Open Archiver image is self-contained, so you do not need to clone the source repository to run the application. You only need two files: the Compose file and the example environment file.
+
+Create a directory for your deployment and download both files:
 
 ```bash
-git clone https://github.com/LogicLabs-OU/OpenArchiver.git
-cd OpenArchiver
+mkdir open-archiver && cd open-archiver
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+curl -L -o .env https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/.env.example
 ```
 
 ## 2. Create a Directory for Local Storage
@@ -36,15 +38,9 @@ This ensures the directory is owned by your current user, which is necessary for
 
 ## 3. Configure Your Environment
 
-The application is configured using environment variables. You'll need to create a `.env` file to store your configuration.
+The application is configured using environment variables. The `.env` file you downloaded in step 1 contains the example configuration.
 
-Copy the example environment file for Docker:
-
-```bash
-cp .env.example .env
-```
-
-Now, open the `.env` file in a text editor and customize the settings.
+Open the `.env` file in a text editor and customize the settings.
 
 ### Key Configuration Steps
 
@@ -230,18 +226,23 @@ After successfully deploying and logging into Open Archiver, the next step is to
 
 ## Updating Your Installation
 
-To update your Open Archiver instance to the latest version, run the following commands:
+To update your Open Archiver instance to the latest version, pull the new images and restart the services from your deployment directory:
 
 ```bash
-# Pull the latest changes from the repository
-git pull
-
 # Pull the latest Docker images
 docker compose pull
 
 # Restart the services with the new images
 docker compose up -d
 ```
+
+If a release announces changes to `compose.yaml` itself (for example a new service or a renamed volume), re-download it before restarting:
+
+```bash
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+```
+
+The release notes will call this out explicitly when it is needed.
 
 ## Deploying on Coolify
 

--- a/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
+++ b/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
@@ -20,7 +20,7 @@ To perform a dumpless upgrade, you need to configure your Meilisearch instance w
 
 **Option 1: Using an Environment Variable**
 
-Add the `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE` environment variable to your `docker-compose.yml` file for the Meilisearch service.
+Add the `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE` environment variable to your `compose.yaml` file for the Meilisearch service.
 
 ```yaml
 services:
@@ -33,7 +33,7 @@ services:
 
 **Option 2: Using a CLI Option**
 
-Alternatively, you can pass the `--experimental-dumpless-upgrade` flag in the command section of your `docker-compose.yml`.
+Alternatively, you can pass the `--experimental-dumpless-upgrade` flag in the command section of your `compose.yaml`.
 
 ```yaml
 services:
@@ -103,8 +103,8 @@ Once the dump is successfully created, you can proceed with the standard Open Ar
 
 Now, you need to restart the services while telling Meilisearch to import from your dump file.
 
-1.  **Modify `docker-compose.yml`**:
-    You need to temporarily add the `--import-dump` flag to the Meilisearch service command. Find the `meilisearch` service in your `docker-compose.yml` and modify the `command` section.
+1.  **Modify `compose.yaml`**:
+    You need to temporarily add the `--import-dump` flag to the Meilisearch service command. Find the `meilisearch` service in your `compose.yaml` and modify the `command` section.
 
     You will need the name of your dump file. It will be a `.dump` file located in the directory mapped to `/meili_data` inside the container.
 
@@ -128,9 +128,9 @@ Now, you need to restart the services while telling Meilisearch to import from y
 
 ### Step 4: Clean Up
 
-Once the import is complete and you have verified that your search is working correctly, you should remove the `--import-dump` flag from your `docker-compose.yml` to prevent it from running on every startup.
+Once the import is complete and you have verified that your search is working correctly, you should remove the `--import-dump` flag from your `compose.yaml` to prevent it from running on every startup.
 
-1.  **Remove the `--import-dump` line** from the `command` section of the `meilisearch` service in `docker-compose.yml`.
+1.  **Remove the `--import-dump` line** from the `command` section of the `meilisearch` service in `compose.yaml`.
 2.  **Restart the services** one last time:
     ```bash
     docker compose up -d

--- a/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
+++ b/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
@@ -87,10 +87,9 @@ Before upgrading, you must create a dump of your existing Meilisearch data. You 
 
 Once the dump is successfully created, you can proceed with the standard Open Archiver upgrade process.
 
-1.  **Pull the latest changes and Docker images**:
+1.  **Pull the latest Docker images**:
 
     ```bash
-    git pull
     docker compose pull
     ```
 

--- a/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
+++ b/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
@@ -20,7 +20,7 @@ To perform a dumpless upgrade, you need to configure your Meilisearch instance w
 
 **Option 1: Using an Environment Variable**
 
-Add the `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE` environment variable to your `docker-compose.yml` file for the Meilisearch service.
+Add the `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE` environment variable to your `compose.yaml` file for the Meilisearch service.
 
 ```yaml
 services:
@@ -33,7 +33,7 @@ services:
 
 **Option 2: Using a CLI Option**
 
-Alternatively, you can pass the `--experimental-dumpless-upgrade` flag in the command section of your `docker-compose.yml`.
+Alternatively, you can pass the `--experimental-dumpless-upgrade` flag in the command section of your `compose.yaml`.
 
 ```yaml
 services:
@@ -120,8 +120,8 @@ Once the dump is successfully created, you can proceed with the standard Open Ar
 
 Now, you need to restart the services while telling Meilisearch to import from your dump file.
 
-1.  **Modify `docker-compose.yml`**:
-    You need to temporarily add the `--import-dump` flag to the Meilisearch service command. Find the `meilisearch` service in your `docker-compose.yml` and add a `command` section:
+1.  **Modify `compose.yaml`**:
+    You need to temporarily add the `--import-dump` flag to the Meilisearch service command. Find the `meilisearch` service in your `compose.yaml` and add a `command` section:
 
     ```yaml
     services:
@@ -152,9 +152,9 @@ Now, you need to restart the services while telling Meilisearch to import from y
 
 ### Step 4: Clean Up
 
-Once the import is complete and you have verified that your search is working correctly, you should remove the `--import-dump` flag from your `docker-compose.yml` to prevent it from running on every startup.
+Once the import is complete and you have verified that your search is working correctly, you should remove the `--import-dump` flag from your `compose.yaml` to prevent it from running on every startup.
 
-1.  **Restore the docker compose file**: Remove the  `command` section of the `meilisearch` service in `docker-compose.yml`.
+1.  **Restore the docker compose file**: Remove the  `command` section of the `meilisearch` service in `compose.yaml`.
 2.  **Restart the services one last time**:
 
     ```bash

--- a/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
+++ b/docs/user-guides/upgrade-and-migration/meilisearch-upgrade.md
@@ -104,10 +104,9 @@ Before upgrading, you must create a dump of your existing Meilisearch data. You 
 
 Once the dump is successfully created, you can proceed with the standard Open Archiver upgrade process.
 
-1.  **Pull the latest changes and Docker images**:
+1.  **Pull the latest Docker images**:
 
     ```bash
-    git pull
     docker compose pull
     ```
 

--- a/docs/user-guides/upgrade-and-migration/upgrade.md
+++ b/docs/user-guides/upgrade-and-migration/upgrade.md
@@ -8,26 +8,28 @@ Open Archiver automatically checks for new versions and will display a notificat
 
 ## Upgrading Your Instance
 
-To upgrade your Open Archiver instance, follow these steps:
+To upgrade your Open Archiver instance, run the following commands from your deployment directory:
 
-1.  **Pull the latest changes from the repository**:
-
-    ```bash
-    git pull
-    ```
-
-2.  **Pull the latest Docker images**:
+1.  **Pull the latest Docker images**:
 
     ```bash
     docker compose pull
     ```
 
-3.  **Restart the services with the new images**:
+2.  **Restart the services with the new images**:
     ```bash
     docker compose up -d
     ```
 
 This will restart your Open Archiver instance with the latest version of the application.
+
+If a release announces changes to `compose.yaml` itself (for example a new service or a renamed volume), re-download it before restarting:
+
+```bash
+curl -O https://raw.githubusercontent.com/LogicLabs-OU/OpenArchiver/main/compose.yaml
+```
+
+The release notes will call this out explicitly when it is needed.
 
 ## Migrating Data
 


### PR DESCRIPTION
Depends on #378 (which renames `docker-compose.yml` to `compose.yaml`). The diff below assumes that rename has landed.

The Open Archiver image is self-contained: backend, frontend, types, migrations, and the entrypoint are all baked in at build time. Nothing from the source tree is read at runtime, so cloning the repository just to start the application is unnecessary.

## Changes

- README and installation guide now instruct users to download `compose.yaml` and `.env.example` directly, instead of cloning the repo.
- The upgrade guide drops the `git pull` step. `docker compose pull` + `docker compose up -d` is enough; re-downloading `compose.yaml` is only needed when a release explicitly changes it.
- Removes the broken reference to `.env.example.docker` (file does not exist in the repo).
- Git is no longer listed as a prerequisite.

## Impact on existing users

None. Existing clones keep working with the unchanged `docker compose` commands. The new flow is only what new users see in the docs.