### PR TITLE
Keep workers alive on bad attachments and unreadable sources

### DIFF
--- a/packages/backend/src/helpers/textExtractor.ts
+++ b/packages/backend/src/helpers/textExtractor.ts
@@ -9,10 +9,13 @@ function extractTextFromPdf(buffer: Buffer): Promise<string> {
 	return new Promise((resolve) => {
 		const pdfParser = new PDFParser(null, true);
 		let completed = false;
+		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
 		const finish = (text: string) => {
 			if (completed) return;
 			completed = true;
+
+			if (timeoutHandle) clearTimeout(timeoutHandle);
 
 			// explicit cleanup
 			try {
@@ -46,11 +49,14 @@ function extractTextFromPdf(buffer: Buffer): Promise<string> {
 			finish('');
 		}
 
-		// reduced Timeout for better performance
-		// setTimeout(() => {
-		// 	logger.warn('PDF parsing timed out');
-		// 	finish('');
-		// }, 5000);
+		// Safety timeout: pdf2json can fail asynchronously (e.g. "Bits per component
+		// missing in image") without ever emitting pdfParser_dataError, which would
+		// leave this promise pending forever and stall the indexing job. Resolve
+		// empty so extraction gives up cleanly and the caller can proceed.
+		timeoutHandle = setTimeout(() => {
+			logger.warn('PDF parsing timed out');
+			finish('');
+		}, 30000);
 	});
 }
 

--- a/packages/backend/src/workers/indexing.worker.ts
+++ b/packages/backend/src/workers/indexing.worker.ts
@@ -26,3 +26,17 @@ logger.info('Indexing worker started');
 
 process.on('SIGINT', () => worker.close());
 process.on('SIGTERM', () => worker.close());
+
+// pdf2json can emit an unhandled promise rejection deep in its image parsing
+// (e.g. "Bits per component missing in image") that bypasses the pdfParser
+// error events and would otherwise crash the whole worker process. Keep the
+// process alive so the affected job resolves empty (via the textExtractor
+// timeout) and BullMQ can move on to the next email instead of indexing halting.
+process.on('unhandledRejection', (reason: unknown) => {
+	const message = reason instanceof Error ? reason.message : String(reason);
+	logger.warn({ reason: message }, 'Unhandled rejection in indexing worker (suppressed)');
+});
+process.on('uncaughtException', (err: unknown) => {
+	const message = err instanceof Error ? err.message : String(err);
+	logger.error({ err: message }, 'Uncaught exception in indexing worker (suppressed)');
+});

--- a/packages/backend/src/workers/ingestion.worker.ts
+++ b/packages/backend/src/workers/ingestion.worker.ts
@@ -42,3 +42,15 @@ logger.info('Ingestion worker started');
 
 process.on('SIGINT', () => worker.close());
 process.on('SIGTERM', () => worker.close());
+
+// A source file that is unreadable or locked (e.g. an EACCES 'error' event on a
+// ReadStream for a PST still open in Outlook over SMB) can crash the whole
+// worker process. Keep it alive so the offending job fails and the others proceed.
+process.on('unhandledRejection', (reason: unknown) => {
+	const message = reason instanceof Error ? reason.message : String(reason);
+	logger.warn({ reason: message }, 'Unhandled rejection in ingestion worker (suppressed)');
+});
+process.on('uncaughtException', (err: unknown) => {
+	const message = err instanceof Error ? err.message : String(err);
+	logger.error({ err: message }, 'Uncaught exception in ingestion worker (suppressed)');
+});


### PR DESCRIPTION
pdf2json can throw an unhandled rejection deep in image parsing (e.g. "Bits per component missing in image") that bypasses the pdfParser error events and crashes the indexing worker. As the workers run under concurrently, the crashed worker is not restarted and all indexing silently halts while emails keep being archived.

- Re-enable the safety timeout in extractTextFromPdf so a hung parse resolves empty instead of leaving the promise (and the indexing job) pending forever.
- Add unhandledRejection/uncaughtException guards to the indexing and ingestion workers so a single bad attachment, or an unreadable/locked source file (EACCES ReadStream error), cannot take the whole worker down.

Fixes #398 