### PR TITLE
Fix attachment download: NFC/NFD path lookup + Content-Disposition encoding

### DIFF
--- a/packages/backend/src/api/controllers/storage.controller.ts
+++ b/packages/backend/src/api/controllers/storage.controller.ts
@@ -40,7 +40,20 @@ export class StorageController {
 
 			const fileStream = await this.storageService.get(safePath);
 			const fileName = path.basename(safePath);
-			res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+
+			// Node's header validation rejects raw non-ASCII bytes (and Unicode
+			// combining marks in particular), throwing ERR_INVALID_CHAR and
+			// crashing the request with a 500 for any attachment whose filename
+			// contains e.g. Cyrillic characters or NFD-decomposed diacritics.
+			// RFC 6266 / RFC 5987 encoding fixes this: an ASCII-safe fallback for
+			// legacy clients, plus a UTF-8 percent-encoded filename* for modern
+			// browsers, which correctly display the original filename.
+			const asciiFallback = fileName.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, "'");
+			const encodedFileName = encodeURIComponent(fileName);
+			res.setHeader(
+				'Content-Disposition',
+				`attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedFileName}`
+			);
 			fileStream.pipe(res);
 		} catch (error) {
 			console.error('Error downloading file:', error);

--- a/packages/backend/src/services/storage/LocalFileSystemProvider.ts
+++ b/packages/backend/src/services/storage/LocalFileSystemProvider.ts
@@ -24,18 +24,48 @@ export class LocalFileSystemProvider implements IStorageProvider {
 		}
 	}
 
+	/**
+	 * Resolves a stored relative path to the exact path on disk.
+	 *
+	 * Attachment filenames can reach this provider in either Unicode NFC or NFD
+	 * normalization form, depending on the mail client that composed the original
+	 * message. The path recorded in the database is not guaranteed to use the same
+	 * normalization form as the byte sequence that was actually written to disk by
+	 * `put()`. Linux filesystems compare filenames byte-for-byte and do not
+	 * normalize Unicode, so a naive `fs.access` on the DB-provided path can fail
+	 * with ENOENT even though a canonically identical file exists on disk.
+	 *
+	 * We try the exact path first (fast path, zero behavior change for the common
+	 * ASCII case), then fall back to the NFC and NFD forms before giving up.
+	 */
+	private async resolveExistingPath(filePath: string): Promise<string | null> {
+		const candidates = Array.from(
+			new Set([filePath, filePath.normalize('NFC'), filePath.normalize('NFD')])
+		);
+
+		for (const candidate of candidates) {
+			const fullPath = path.join(this.rootPath, candidate);
+			try {
+				await fs.access(fullPath);
+				return fullPath;
+			} catch {
+				// try next candidate
+			}
+		}
+
+		return null;
+	}
+
 	async get(filePath: string): Promise<NodeJS.ReadableStream> {
-		const fullPath = path.join(this.rootPath, filePath);
-		try {
-			await fs.access(fullPath);
-			return createReadStream(fullPath);
-		} catch (error) {
+		const fullPath = await this.resolveExistingPath(filePath);
+		if (!fullPath) {
 			throw new Error('File not found');
 		}
+		return createReadStream(fullPath);
 	}
 
 	async delete(filePath: string): Promise<void> {
-		const fullPath = path.join(this.rootPath, filePath);
+		const fullPath = (await this.resolveExistingPath(filePath)) ?? path.join(this.rootPath, filePath);
 		try {
 			await fs.rm(fullPath, { recursive: true, force: true });
 		} catch (error: any) {
@@ -47,12 +77,6 @@ export class LocalFileSystemProvider implements IStorageProvider {
 	}
 
 	async exists(filePath: string): Promise<boolean> {
-		const fullPath = path.join(this.rootPath, filePath);
-		try {
-			await fs.access(fullPath);
-			return true;
-		} catch {
-			return false;
-		}
+		return (await this.resolveExistingPath(filePath)) !== null;
 	}
 }


### PR DESCRIPTION
Fixes #409.

## Summary

Two compounding bugs in `GET /api/v1/storage/download` for attachments with non-ASCII filenames:

1. **`LocalFileSystemProvider`** resolved the DB-provided `storage_path` with a plain `fs.access()` on the exact byte sequence. Linux filesystems compare filenames byte-for-byte without Unicode normalization — if the DB value uses a different NFC/NFD normalization form than the bytes actually written to disk at ingestion time, the lookup fails with `404` even though a canonically identical file exists.
2. **`storage.controller.ts`** set `Content-Disposition` with the raw filename, which throws `ERR_INVALID_CHAR` (crashing the request with a `500`) for filenames containing characters outside Node's allowed header range — Cyrillic (as reported in #406), but also NFD-decomposed diacritics (combining marks). This is why fixing (1) alone still fails for umlaut filenames once they're located via their NFD form — the two bugs compound on real-world attachments.

Both are fixed here since a complete fix needs both; this PR also resolves #406.

## Changes

- `LocalFileSystemProvider`: new `resolveExistingPath()` helper tries the exact path first (zero behavior change for the common ASCII case), then falls back to `.normalize('NFC')` and `.normalize('NFD')` before returning "not found". Used by `get()`, `exists()`, `delete()`.
- `storage.controller.ts`: RFC 6266/5987-encode the `Content-Disposition` filename (ASCII fallback + `filename*=UTF-8''<percent-encoded>`). No new dependency.

## Testing

Reproduced and verified against a real Open Archiver v0.5.1 instance (local storage, Docker Compose):
- Requesting the exact DB `storage_path` for an attachment with an NFD-vs-NFC mismatched filename → `404` before the fix.
- Requesting the NFD-corrected path → `500` / `ERR_INVALID_CHAR` before the fix (the #406 bug).
- Both files transpile cleanly with `tsc` (`--module commonjs --target es2020 --skipLibCheck`, no syntax errors) after the change; `resolveExistingPath` logic sanity-checked standalone with Node.

Full repro details and root-cause analysis are in #409.
