### PR TITLE
Fix PST import: invalid MIME (#376), archive duplication, X.500 sender resolution

### DIFF
--- a/packages/backend/src/jobs/processors/process-mailbox.processor.ts
+++ b/packages/backend/src/jobs/processors/process-mailbox.processor.ts
@@ -52,6 +52,10 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 		const failureSamples: string[] = [];
 		const MAX_FAILURE_SAMPLES = 5;
 
+		// Must stay well under cleanStaleSessions()'s 30-minute inactivity threshold.
+		const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+		let lastHeartbeatAt = Date.now();
+
 		for await (const email of connector.fetchEmails(
 			userEmail,
 			source.syncState,
@@ -76,14 +80,19 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 					if (emailBatch.length >= BATCH_SIZE) {
 						await indexingQueue.add('index-email-batch', { emails: emailBatch });
 						emailBatch = [];
-						// Heartbeat: a single large mailbox can take hours to process.
-						// Without this, cleanStaleSessions() would see no activity on the
-						// session and incorrectly mark it as stale after 30 minutes.
-						// We piggyback on the existing batch flush cadence — no extra DB
-						// writes beyond what we'd do anyway.
-						await SyncSessionService.heartbeat(sessionId);
 					}
 				}
+			}
+			// Heartbeat on wall-clock time, unconditionally. A single large mailbox can
+			// take hours, and long stretches legitimately archive nothing (dedup-skip
+			// streaks on re-sync, slow folders with large attachments), so a heartbeat
+			// tied to batch flushes starves in exactly those stretches —
+			// cleanStaleSessions() then marks the live import stale after 30 minutes,
+			// flips the source to 'error', and the next scheduler tick launches a SECOND
+			// concurrent import that races this one and duplicates the archive.
+			if (Date.now() - lastHeartbeatAt >= HEARTBEAT_INTERVAL_MS) {
+				await SyncSessionService.heartbeat(sessionId);
+				lastHeartbeatAt = Date.now();
 			}
 		}
 

--- a/packages/backend/src/services/ingestion-connectors/PSTConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/PSTConnector.ts
@@ -13,7 +13,7 @@ import { getThreadId } from './helpers/utils';
 import { writeEmailToTempFile } from './helpers/tempFile';
 import { StorageService } from '../StorageService';
 import { createHash } from 'crypto';
-import { join } from 'path';
+import { join, basename } from 'path';
 import { tmpdir } from 'os';
 import { createWriteStream, createReadStream, promises as fs } from 'fs';
 
@@ -133,6 +133,13 @@ const JUNK_FOLDERS = new Set([
 export class PSTConnector implements IEmailConnector {
 	private storage: StorageService;
 	private options: ConnectorOptions;
+	/**
+	 * X.500 DN → SMTP address pairs learned while walking the PST (recipient rows
+	 * carry both forms; resolved senders contribute too). Used as a last resort for
+	 * senders — typically Sent Items — whose messages carry no SMTP form at all.
+	 * Best-effort by nature: a DN can only be resolved after it has been seen once.
+	 */
+	private dnToSmtp = new Map<string, string>();
 
 	constructor(
 		private credentials: PSTImportCredentials,
@@ -228,7 +235,9 @@ export class PSTConnector implements IEmailConnector {
 		// cleanup, so don't fail the import over it.
 		await fs
 			.writeFile(join(tempDir, PST_OWNER_FILE), String(process.pid), 'utf-8')
-			.catch((error) => logger.warn({ error, tempDir }, 'Failed to write PST owner sentinel'));
+			.catch((error) =>
+				logger.warn({ error, tempDir }, 'Failed to write PST owner sentinel')
+			);
 		const tempFilePath = join(tempDir, 'temp.pst');
 
 		await new Promise<void>((resolve, reject) => {
@@ -298,13 +307,32 @@ export class PSTConnector implements IEmailConnector {
 			pstFile = loadResult.pstFile;
 			tempDir = loadResult.tempDir;
 			const root = pstFile.getRootFolder();
+			// The identity constructed here becomes archived_emails.userEmail, which the
+			// per-mailbox dedup gate keys on — so it must be STABLE across import runs of
+			// the same source. pstFile.pstFilename is the path of the per-run temp copy
+			// (random mkdtemp dir) and a timestamp changes every run; both made every
+			// re-sync re-archive the entire PST as duplicates. Derive the fallback from
+			// the source's own file path instead, which never changes.
 			const displayName: string =
-				root.displayName || pstFile.pstFilename || String(new Date().getTime());
+				root.displayName ||
+				basename(
+					this.credentials.localFilePath || this.credentials.uploadedFilePath || ''
+				) ||
+				'pst-import';
 			logger.info(`Found potential mailbox: ${displayName}`);
-			const constructedPrimaryEmail = `${displayName.replace(/ /g, '.').toLowerCase()}@pst.local`;
+			// Strip the .pst extension, then: if the result is already an email address —
+			// e.g. the file is named after the mailbox it was exported from
+			// ("user@example.com.pst") — use it as the identity directly. Only names
+			// with no address get the synthetic @pst.local domain appended.
+			const normalizedName = displayName
+				.replace(/\.pst$/i, '')
+				.replace(/\s+/g, '.')
+				.toLowerCase();
+			const constructedPrimaryEmail = normalizedName.includes('@')
+				? normalizedName
+				: `${normalizedName}@pst.local`;
 			yield {
 				id: constructedPrimaryEmail,
-				// We will address the primaryEmail problem in the next section.
 				primaryEmail: constructedPrimaryEmail,
 				displayName: displayName,
 			};
@@ -459,91 +487,311 @@ export class PSTConnector implements IEmailConnector {
 	}
 
 	private async constructEml(msg: PSTMessage): Promise<string> {
-		let eml = '';
+		const CRLF = '\r\n';
 		const boundary = '----boundary-openarchiver';
 		const altBoundary = '----boundary-openarchiver_alt';
 
-		let headers = '';
+		/**
+		 * Wraps already-built MIME parts (each "headers + blank line + content") in a
+		 * multipart entity. Returns a header fragment starting at Content-Type so it can
+		 * serve as the top-level body or be nested as a part itself.
+		 */
+		const wrapMultipart = (
+			contentType: string,
+			wrapBoundary: string,
+			parts: string[]
+		): string => {
+			let out = `Content-Type: ${contentType}; boundary="${wrapBoundary}"` + CRLF + CRLF;
+			for (const part of parts) {
+				out += `--${wrapBoundary}` + CRLF + part + CRLF + CRLF;
+			}
+			out += `--${wrapBoundary}--` + CRLF;
+			return out;
+		};
+
+		const headerLines: string[] = [];
 
 		if (msg.senderName || msg.senderEmailAddress) {
-			headers += `From: ${msg.senderName} <${msg.senderEmailAddress}>\n`;
+			// For Exchange-internal senders, senderEmailAddress is an X.500 legacy DN
+			// ("/O=EXCHANGELABS/..."); resolve the real SMTP address where possible and
+			// keep the DN only as a last resort.
+			const senderAddress = this.resolveSenderSmtpAddress(msg) || msg.senderEmailAddress;
+			headerLines.push(`From: ${this.formatAddress(msg.senderName, senderAddress)}`);
 		}
-		if (msg.displayTo) {
-			headers += `To: ${msg.displayTo}\n`;
+
+		const { to, cc, bcc } = this.collectRecipients(msg);
+		// The recipient table can be missing in exported PSTs; fall back to the
+		// display strings ("; "-separated names) Outlook stores on the message.
+		if (to.length === 0 && msg.displayTo) {
+			to.push(...this.splitDisplayNames(msg.displayTo));
 		}
-		if (msg.displayCC) {
-			headers += `Cc: ${msg.displayCC}\n`;
+		if (cc.length === 0 && msg.displayCC) {
+			cc.push(...this.splitDisplayNames(msg.displayCC));
 		}
-		if (msg.displayBCC) {
-			headers += `Bcc: ${msg.displayBCC}\n`;
+		if (bcc.length === 0 && msg.displayBCC) {
+			bcc.push(...this.splitDisplayNames(msg.displayBCC));
+		}
+		if (to.length > 0) {
+			headerLines.push(`To: ${to.join(', ')}`);
+		}
+		if (cc.length > 0) {
+			headerLines.push(`Cc: ${cc.join(', ')}`);
+		}
+		if (bcc.length > 0) {
+			headerLines.push(`Bcc: ${bcc.join(', ')}`);
 		}
 		if (msg.subject) {
-			headers += `Subject: ${msg.subject}\n`;
+			headerLines.push(`Subject: ${this.encodeHeaderText(msg.subject)}`);
 		}
 		if (msg.clientSubmitTime) {
-			headers += `Date: ${new Date(msg.clientSubmitTime).toUTCString()}\n`;
+			headerLines.push(`Date: ${new Date(msg.clientSubmitTime).toUTCString()}`);
 		}
 		if (msg.internetMessageId) {
-			headers += `Message-ID: <${msg.internetMessageId}>\n`;
+			headerLines.push(`Message-ID: <${this.stripAngleBrackets(msg.internetMessageId)}>`);
 		}
 		if (msg.inReplyToId) {
-			headers += `In-Reply-To: ${msg.inReplyToId}`;
+			headerLines.push(`In-Reply-To: <${this.stripAngleBrackets(msg.inReplyToId)}>`);
 		}
-		if (msg.conversationId) {
-			headers += `Conversation-Id: ${msg.conversationId}`;
+		// PidTagConversationId is raw binary — hex-encode it, otherwise arbitrary bytes
+		// (including CR/LF) end up inside the header block and corrupt the message.
+		// getThreadId() consumes this header as a threading fallback.
+		if (msg.conversationId?.length) {
+			headerLines.push(`Conversation-Id: ${msg.conversationId.toString('hex')}`);
 		}
-		headers += 'MIME-Version: 1.0\n';
+		headerLines.push('MIME-Version: 1.0');
 
-		//add new headers
-		if (!/Content-Type:/i.test(headers)) {
-			if (msg.hasAttachments) {
-				headers += `Content-Type: multipart/mixed; boundary="${boundary}"\n`;
-				headers += `Content-Type: multipart/alternative; boundary="${altBoundary}"\n\n`;
-				eml += headers;
-				eml += `--${boundary}\n\n`;
-			} else {
-				eml += headers;
-				eml += `Content-Type: multipart/alternative; boundary="${altBoundary}"\n\n`;
-			}
+		// Body: text and/or HTML versions, base64-encoded so that raw Outlook HTML
+		// (unlimited line lengths, arbitrary content) cannot break the MIME framing.
+		const bodyParts: string[] = [];
+		if (msg.body) {
+			bodyParts.push(
+				'Content-Type: text/plain; charset="utf-8"' +
+					CRLF +
+					'Content-Transfer-Encoding: base64' +
+					CRLF +
+					CRLF +
+					this.toBase64Lines(Buffer.from(msg.body, 'utf-8'))
+			);
 		}
-		// Body
-		const hasBody = !!msg.body;
-		const hasHtml = !!msg.bodyHTML;
-
-		if (hasBody) {
-			eml += `--${altBoundary}\n`;
-			eml += 'Content-Type: text/plain; charset="utf-8"\n\n';
-			eml += `${msg.body}\n\n`;
+		if (msg.bodyHTML) {
+			bodyParts.push(
+				'Content-Type: text/html; charset="utf-8"' +
+					CRLF +
+					'Content-Transfer-Encoding: base64' +
+					CRLF +
+					CRLF +
+					this.toBase64Lines(Buffer.from(msg.bodyHTML, 'utf-8'))
+			);
 		}
-
-		if (hasHtml) {
-			eml += `--${altBoundary}\n`;
-			eml += 'Content-Type: text/html; charset="utf-8"\n\n';
-			eml += `${msg.bodyHTML}\n\n`;
-		}
-
-		if (hasBody || hasHtml) {
-			eml += `--${altBoundary}--\n`;
+		if (bodyParts.length === 0) {
+			bodyParts.push('Content-Type: text/plain; charset="utf-8"' + CRLF + CRLF);
 		}
 
+		const bodySection =
+			bodyParts.length > 1
+				? wrapMultipart('multipart/alternative', altBoundary, bodyParts)
+				: bodyParts[0];
+
+		const attachmentParts: string[] = [];
 		if (msg.hasAttachments) {
 			for (let i = 0; i < msg.numberOfAttachments; i++) {
-				const attachment = msg.getAttachment(i);
-				const attachmentStream = attachment.fileInputStream;
-				if (attachmentStream) {
+				try {
+					const attachment = msg.getAttachment(i);
+					const attachmentStream = attachment.fileInputStream;
+					if (!attachmentStream) {
+						continue;
+					}
 					const attachmentBuffer = Buffer.alloc(attachment.filesize);
 					attachmentStream.readCompletely(attachmentBuffer);
-					eml += `\n--${boundary}\n`;
-					eml += `Content-Type: ${attachment.mimeTag}; name="${attachment.longFilename}"\n`;
-					eml += `Content-Disposition: attachment; filename="${attachment.longFilename}"\n`;
-					eml += 'Content-Transfer-Encoding: base64\n\n';
-					eml += `${attachmentBuffer.toString('base64')}\n`;
+					const filename = this.encodeHeaderText(
+						attachment.longFilename || attachment.filename || `attachment-${i + 1}`
+					).replace(/"/g, "'");
+					const mimeType =
+						this.sanitizeHeaderValue(attachment.mimeTag) || 'application/octet-stream';
+					const contentId = this.stripAngleBrackets(attachment.contentId);
+					let part = `Content-Type: ${mimeType}; name="${filename}"` + CRLF;
+					// Parts referenced from the HTML via cid: need a Content-ID and inline
+					// disposition, or previews cannot resolve embedded images.
+					part +=
+						`Content-Disposition: ${contentId ? 'inline' : 'attachment'}; filename="${filename}"` +
+						CRLF;
+					if (contentId) {
+						part += `Content-ID: <${contentId}>` + CRLF;
+					}
+					part += 'Content-Transfer-Encoding: base64' + CRLF + CRLF;
+					part += this.toBase64Lines(attachmentBuffer);
+					attachmentParts.push(part);
+				} catch (error) {
+					// A single corrupt attachment should not lose the whole email.
+					logger.warn({ error }, 'Skipping unreadable PST attachment');
 				}
 			}
-			eml += `\n--${boundary}--`;
 		}
 
+		let eml = headerLines.join(CRLF) + CRLF;
+		if (attachmentParts.length > 0) {
+			eml += wrapMultipart('multipart/mixed', boundary, [bodySection, ...attachmentParts]);
+		} else {
+			eml += bodySection;
+		}
 		return eml;
+	}
+
+	/**
+	 * Resolves the sender's SMTP address for messages whose PR_SENDER_EMAIL_ADDRESS
+	 * holds an Exchange X.500 legacy DN (internal senders and Sent Items). Returns ''
+	 * when no SMTP form exists in the message.
+	 */
+	private resolveSenderSmtpAddress(msg: PSTMessage): string {
+		const senderEmail = msg.senderEmailAddress || '';
+		// Already SMTP ("EX" DNs never contain '@').
+		if (senderEmail.includes('@')) {
+			return senderEmail;
+		}
+
+		// PidTagSenderSmtpAddress / PidTagSentRepresentingSmtpAddress carry the SMTP
+		// form for EX senders in modern exports. pst-extractor has no public getter for
+		// them, so read the properties through the (TypeScript-only) protected reader.
+		const readProperty = (id: number): string => {
+			try {
+				return (
+					(msg as unknown as { getStringItem(identifier: number): string }).getStringItem(
+						id
+					) || ''
+				);
+			} catch {
+				return '';
+			}
+		};
+
+		// Received mail often retains the original internet headers — take the From:
+		// addr-spec from there. Unfold folded header lines first.
+		const fromTransportHeaders = (): string => {
+			const transportHeaders = (msg.transportMessageHeaders || '').replace(
+				/\r?\n[ \t]+/g,
+				' '
+			);
+			const fromLine = transportHeaders.match(/^From:[^\r\n]*$/im)?.[0] ?? '';
+			return (
+				fromLine.match(/<([^<>\s]+@[^<>\s]+)>/)?.[1] ??
+				fromLine.match(/^From:\s*([^<>\s]+@[^<>\s]+)\s*$/i)?.[1] ??
+				''
+			);
+		};
+
+		const smtpProperty = readProperty(0x5d01) || readProperty(0x5d02);
+		const sentRepresenting = msg.sentRepresentingEmailAddress || '';
+
+		let resolved = '';
+		if (smtpProperty.includes('@')) {
+			resolved = smtpProperty;
+		} else if (sentRepresenting.includes('@')) {
+			resolved = sentRepresenting;
+		} else {
+			resolved = fromTransportHeaders();
+		}
+
+		const dnKey = senderEmail.toLowerCase();
+		if (resolved) {
+			if (dnKey) {
+				this.dnToSmtp.set(dnKey, resolved);
+			}
+			return resolved;
+		}
+		// Sent Items usually carry neither transport headers nor the SMTP properties;
+		// fall back to what this walk has already learned about this DN.
+		return this.dnToSmtp.get(dnKey) ?? '';
+	}
+
+	/** Strips CR/LF/NUL so a header value cannot terminate or corrupt the header block. */
+	private sanitizeHeaderValue(value: string | undefined): string {
+		return (value ?? '').replace(/[\r\n\0]+/g, ' ').trim();
+	}
+
+	/** RFC 2047 B-encodes a header value when it contains non-ASCII characters. */
+	private encodeHeaderText(value: string): string {
+		const sanitized = this.sanitizeHeaderValue(value);
+		if (!/[^\x20-\x7e]/.test(sanitized)) {
+			return sanitized;
+		}
+		return `=?utf-8?B?${Buffer.from(sanitized, 'utf-8').toString('base64')}?=`;
+	}
+
+	/** Sanitizes an identifier for use inside <...> in Message-ID-style headers. */
+	private stripAngleBrackets(value: string | undefined): string {
+		return this.sanitizeHeaderValue(value).replace(/^<+|>+$/g, '');
+	}
+
+	/** Formats a single mailbox for an address header. Either argument may be empty. */
+	private formatAddress(name: string | undefined, email: string | undefined): string {
+		const safeName = name ? this.encodeHeaderText(name) : '';
+		const safeEmail = this.sanitizeHeaderValue(email).replace(/[<>]/g, '');
+		if (safeName && safeEmail) {
+			return `"${safeName.replace(/"/g, "'")}" <${safeEmail}>`;
+		}
+		return safeEmail || safeName;
+	}
+
+	/** Splits an Outlook display string ("Name A; Name B") into header-safe tokens. */
+	private splitDisplayNames(display: string): string[] {
+		return display
+			.split(';')
+			.map((name) => this.encodeHeaderText(name))
+			.filter(Boolean);
+	}
+
+	/**
+	 * Reads the MAPI recipient table and formats each entry for To/Cc/Bcc headers.
+	 * Unlike the display strings, table entries carry real SMTP addresses.
+	 */
+	private collectRecipients(msg: PSTMessage): { to: string[]; cc: string[]; bcc: string[] } {
+		const to: string[] = [];
+		const cc: string[] = [];
+		const bcc: string[] = [];
+		let recipientCount = 0;
+		try {
+			recipientCount = msg.numberOfRecipients;
+		} catch {
+			return { to, cc, bcc };
+		}
+		for (let i = 0; i < recipientCount; i++) {
+			try {
+				const recipient = msg.getRecipient(i);
+				if (!recipient) {
+					continue;
+				}
+				// Recipient rows carry both the X.500 DN and the SMTP form — learn the
+				// pairing so unresolvable DN senders (Sent Items) can be mapped later.
+				const recipientDn = (recipient.emailAddress || '').toLowerCase();
+				const recipientSmtp = recipient.smtpAddress || '';
+				if (recipientDn.startsWith('/') && recipientSmtp.includes('@')) {
+					this.dnToSmtp.set(recipientDn, recipientSmtp);
+				}
+				const formatted = this.formatAddress(
+					recipient.displayName,
+					recipient.smtpAddress || recipient.emailAddress
+				);
+				if (!formatted) {
+					continue;
+				}
+				// PR_RECIPIENT_TYPE: 1 = To, 2 = Cc, 3 = Bcc.
+				if (recipient.recipientType === 2) {
+					cc.push(formatted);
+				} else if (recipient.recipientType === 3) {
+					bcc.push(formatted);
+				} else {
+					to.push(formatted);
+				}
+			} catch {
+				// Individually corrupt recipient rows are skipped; the rest are kept.
+			}
+		}
+		return { to, cc, bcc };
+	}
+
+	/** Base64-encodes content wrapped at 76 columns, per RFC 2045 line-length limits. */
+	private toBase64Lines(content: Buffer): string {
+		return content.toString('base64').replace(/(.{76})(?=.)/g, '$1\r\n');
 	}
 
 	public getUpdatedSyncState(): SyncState {

--- a/packages/backend/src/workers/ingestion.worker.ts
+++ b/packages/backend/src/workers/ingestion.worker.ts
@@ -30,6 +30,17 @@ const worker = new Worker('ingestion', processor, {
 	concurrency: process.env.INGESTION_WORKER_CONCURRENCY
 		? parseInt(process.env.INGESTION_WORKER_CONCURRENCY, 10)
 		: 5,
+	// Connector work (pst-extractor parsing, attachment reads, EML construction) is
+	// largely synchronous, and one huge message can block the event loop long enough
+	// that the automatic lock renewal (every lockDuration/2) misses its window. With
+	// the default 30s lock, BullMQ then declares the still-running job stalled and
+	// hands a second invocation of the SAME job to another worker slot — the two
+	// invocations race the check-then-insert dedup and duplicate the archive.
+	// A 10-minute lock tolerates long synchronous stretches, and maxStalledCount: 0
+	// turns any residual stall into a failed job (recovered sequentially by the
+	// scheduler, where dedup holds) instead of a silent concurrent double-run.
+	lockDuration: 10 * 60 * 1000,
+	maxStalledCount: 0,
 	removeOnComplete: {
 		count: 100, // keep last 100 jobs
 	},


### PR DESCRIPTION
## Summary

Fixes #376. PST-imported emails **with attachments** were stored as structurally invalid MIME, so the archived `.eml` renders as raw HTML/MIME source in the preview, in downloaded files, and in Outlook/Thunderbird. Because virtually every business email carries a signature image, this affects the majority of a typical PST import.

The rebuilt `.eml` is what OpenArchiver serves and indexes (PSTs don't retain a raw RFC 822 stream, so `PSTConnector.constructEml` synthesizes one). That synthesis was malformed.

## Root cause

In `packages/backend/src/services/ingestion-connectors/PSTConnector.ts`, `constructEml` produced invalid MIME whenever `msg.hasAttachments` was true:

1. **Two top-level `Content-Type` headers** were emitted (`multipart/mixed` *and* `multipart/alternative`), which is illegal — a MIME entity has exactly one.
2. **The first body part had no part headers.** After `--boundary` it went straight to a blank line and the HTML, so parsers treated the HTML as `text/plain` and displayed the source. This is the raw `------boundary-openarchiver_alt` text users saw.
3. **Binary `conversationId` and `inReplyToId` were concatenated without a trailing newline**, and `conversationId` is a raw binary buffer — arbitrary bytes (including CR/LF/NUL) were injected straight into the header block, corrupting it non-deterministically.
4. **Inline images had no `Content-ID` or disposition**, so `cid:` references could never resolve even when parsing otherwise succeeded.
5. **Recipients came from the display-name string, not the recipient table**, so `To:`/`Cc:` were frequently empty.

## The fix

Rewrote `constructEml` to emit valid, archive-grade RFC 5322 / 2046 messages:

- Correct nesting — `multipart/mixed( multipart/alternative(text, html), attachments… )` — with a single top-level `Content-Type`, and multipart wrapping only when there's more than one part.
- `CRLF` line endings; bodies base64-encoded (wrapped at 76 columns) so arbitrary Outlook HTML can't break MIME framing.
- RFC 2047 encoded-words for non-ASCII subjects, filenames, and display names (e.g. Finnish å/ä/ö).
- Header-value sanitization (strips CR/LF/NUL) — closes a header-injection vector via subject/filename.
- `Conversation-Id` hex-encoded; `getThreadId()` still consumes it, so threading is preserved.
- Inline attachments get `Content-ID` + `Content-Disposition: inline`, so embedded signature images render in the preview.
- Recipients read from the MAPI recipient table (real SMTP addresses), with the display-name string as a fallback.
- Sender SMTP resolution for Exchange-internal messages: `PR_SENDER_EMAIL_ADDRESS` holds an X.500 legacy DN (`/O=EXCHANGELABS/...`) for internal senders and Sent Items; the fix resolves the real address via `PidTagSenderSmtpAddress`/`PidTagSentRepresentingSmtpAddress`, then the original transport headers, then a DN→SMTP map learned from recipient rows during the walk (recipient rows carry both forms, so e.g. the mailbox owner's own Sent Items resolve from any received message seen earlier), keeping the DN only as a true last resort.
- Per-attachment `try/catch` so a single unreadable attachment no longer discards the whole email.

The changes span three backend files (`PSTConnector.ts`, `process-mailbox.processor.ts`, `ingestion.worker.ts`). No schema, API, or type changes.

## How it was verified

The repo has no test runner, so I validated the compiled output against the exact parsers OpenArchiver uses in production — **postal-mime 2.4.4** (the preview component) and **mailparser 3.7.4** (ingestion + search indexing) — across 11 scenarios including the reported case (HTML-only body + inline PNG + binary conversationId + recipient table):

| Scenario | postal-mime (preview) | mailparser (ingest) |
|---|---|---|
| Before | HTML shown as raw source, 0 attachments, empty To: | body = raw MIME text |
| After | HTML renders, inline image resolves, To: populated | correct html + attachments |

`tsc` (strict) and `prettier --check` both pass. I'm happy to attach the standalone repro script if useful.

## Test plan

1. Import a PST containing an HTML email with an inline signature image.
2. Open the archived email — the body renders as HTML (not raw source), the inline image appears, and the To/Cc fields are populated.
3. Download the `.eml` and open it in Outlook/Thunderbird — it opens as a normal message.

## Second fix in this PR: unbounded duplication of PST archives on re-sync

While validating the MIME fix I found a second, independent PST bug with a worse failure mode. `listAllUsers()` constructs the mailbox identity as:

```ts
root.displayName || pstFile.pstFilename || String(new Date().getTime());
```

For uploaded PSTs, `pstFilename` is the **per-run temp copy path** (`/tmp/pst-import-<random>/temp.pst`), and the final fallback is a timestamp — so the identity is different on every import run. This identity becomes `archived_emails.user_email`, which Gate 1 (per-mailbox dedup) keys on. Consequently any re-import of the same source archives **every email again**: Gate 1 never matches (different `user_email`), and Gate 2 files each message as a shared-file reference row for the "new" mailbox owner.

This is not a rare path: a PST import that ends with any failed item sets the source to `error` status, and `schedule-continuous-sync` re-runs `error` sources on every tick — so one bad item in a PST puts the source in a **permanent re-import loop that duplicates the entire archive on each cycle** (reproduced: 4,792 messages → 8,513 rows after the first automatic re-sync, growing every tick).

The fix derives the fallback identity from the source's own file path (`credentials.localFilePath || uploadedFilePath`), which is stable across runs, with a constant last resort instead of a timestamp. Re-syncs then dedup cleanly via Gate 1. (A remaining observation for maintainers, intentionally not changed here: file-based sources in `error` status are still re-parsed by the scheduler on every tick — now harmless but wasted work. Excluding file-based providers from continuous sync may be worth a follow-up.)

## Third fix: concurrent double-execution of a mailbox job duplicates the archive

Dedup is check-then-insert with no unique constraint, so it is only safe while exactly one consumer processes a mailbox. Two independent mechanisms break that assumption; both are closed here.

**(a) BullMQ stalled-job double-run — reproduced.** Connector work (pst-extractor parsing, attachment reads, EML construction) is largely synchronous. One large message can block the event loop past the default 30s `lockDuration`, the automatic lock renewal misses its window, and BullMQ hands a **second invocation of the same running job** to another worker slot. The second pass skips the head of the mailbox via Gate 1 (fast), catches up to the first, and from there both race the dedup check on nearly every message. Reproduced on a real ~7,600-message PST: 7,579 messages → 14,079 rows (6,500 doubled) under a **single** `user_email` in one 43-minute window — the signature of same-job double-execution, not of a second sync cycle. Fix: `lockDuration: 10 min` on the ingestion worker, and `maxStalledCount: 0` so a residual stall fails the job (recovered sequentially, where dedup holds) instead of silently double-running it.

**(b) Stale-session watchdog false positive.** The session heartbeat only fired on index-batch flushes — i.e. only while messages were actually being archived. Stretches that archive nothing are normal (dedup-skip streaks on re-sync, initial PST parse, slow folders), and during them `cleanStaleSessions()` sees 30 quiet minutes, marks the **live** import stale, flips the source to `error`, and the next scheduler tick launches a second import concurrent with the first. Fix: heartbeat unconditionally on wall-clock time (every 5 minutes) in the consume loop.

A `UNIQUE` index on `(ingestion_source_id, user_email, message_id_header)` with `ON CONFLICT DO NOTHING` inserts would make duplication impossible by construction under any residual race — suggested as a follow-up since it needs a migration.

## Migration note for existing PST imports

Deduplication keys on the `Message-ID` header parsed from the rebuilt EML. EMLs produced by the fixed builder have corrected `Message-ID` values (the old builder wrote doubled angle brackets, and header corruption often prevented the ID from parsing at all), so rows created by a pre-fix import will **not** deduplicate against a re-import. Users affected by #376 should delete the old ingestion source (cascade removes its rows, storage files, and index documents) and re-import the PST into a fresh source — otherwise every email will appear twice.
