### PR TITLE
perf(imap): Improve performance of processing messages from IMAP ingestion

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+	"name": "OpenArchiver Dev",
+	// Reuse the project's backing services (postgres, valkey, meilisearch, tika)
+	// from the root compose file, and add a `dev` service on top for the editor
+	// to attach to. Both files are merged into one compose project so the dev
+	// container shares the open-archiver-net network with the services.
+	"dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
+	"service": "dev",
+	"workspaceFolder": "/workspaces/OpenArchiver",
+	// Start the dev container + backing services only. The prebuilt production
+	// `open-archiver` service from the root compose is intentionally NOT started
+	// here — we run the app from source inside `dev` (pnpm dev:oss).
+	"runServices": ["dev", "postgres", "valkey", "meilisearch", "tika"],
+	"remoteUser": "node",
+	// 3000/4000 run inside `dev`; the service:port entries forward ports that
+	// live in the sibling service containers.
+	"forwardPorts": [3000, 4000, "meilisearch:7700", "postgres:5432"],
+	"portsAttributes": {
+		"3000": { "label": "Frontend (SvelteKit)", "onAutoForward": "notify" },
+		"4000": { "label": "Backend API", "onAutoForward": "notify" }
+	},
+	"postCreateCommand": "bash .devcontainer/post-create.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"svelte.svelte-vscode",
+				"esbenp.prettier-vscode",
+				"ms-azuretools.vscode-docker",
+				"vitest.explorer",
+				"yoavbls.pretty-ts-errors"
+			],
+			"settings": {
+				"editor.defaultFormatter": "esbenp.prettier-vscode",
+				"editor.formatOnSave": true,
+				"typescript.tsdk": "node_modules/typescript/lib"
+			}
+		}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,32 @@
+# Devcontainer overlay — merged on top of ../docker-compose.yml.
+#
+# Adds a `dev` service (Node 22 + pnpm) that mounts the source tree and joins
+# the same open-archiver-net network as the backing services (postgres, valkey,
+# meilisearch, tika) defined in the root compose file, so the app running from
+# source inside `dev` reaches them by their service names — exactly like the
+# production container does.
+services:
+    dev:
+        image: mcr.microsoft.com/devcontainers/typescript-node:22
+        # Keep the container alive; VS Code execs into it. (Compose-based
+        # devcontainers must supply their own long-running command.)
+        command: sleep infinity
+        volumes:
+            # Relative paths in compose files resolve against the compose
+            # *project directory*, which the devcontainer CLI sets to the repo
+            # root (the first -f file's dir) — NOT this .devcontainer folder. So
+            # `.` is the repo root here; `..` would (wrongly) mount its parent.
+            - .:/workspaces/OpenArchiver:cached
+            # Persist pnpm's content-addressable store across rebuilds so
+            # installs stay fast. node_modules itself lives in the bind mount.
+            - oa-pnpm-store:/home/node/.local/share/pnpm
+        depends_on:
+            - postgres
+            - valkey
+            - meilisearch
+            - tika
+        networks:
+            - open-archiver-net
+
+volumes:
+    oa-pnpm-store:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Runs once after the dev container is created (see devcontainer.json).
+set -euo pipefail
+
+# The pnpm store is a named volume; Docker mounts it root-owned. Hand it to the
+# `node` user so pnpm can write to it. (The MS devcontainer image grants node
+# passwordless sudo.)
+sudo chown -R node:node /home/node/.local/share/pnpm 2>/dev/null || true
+
+# Activate the exact pnpm pinned by package.json's packageManager field.
+sudo corepack enable
+corepack prepare pnpm@10.13.1 --activate
+
+# Seed a working .env on fresh clones. An existing .env (e.g. yours) is left
+# untouched.
+if [ ! -f .env ]; then
+	cp .env.example .env
+	echo "Created .env from .env.example — review secrets before running."
+fi
+
+# Install workspace dependencies, then build the shared types package so that
+# backend/frontend imports of @open-archiver/types (and tsc / vitest) resolve
+# immediately without a full app build.
+pnpm install
+pnpm --filter @open-archiver/types build
+
+cat <<'EOF'
+
+Dev container ready. Backing services (postgres, valkey, meilisearch, tika) are
+already running on open-archiver-net. Common next steps:
+
+  pnpm db:migrate     # apply the database schema
+  pnpm dev:oss        # frontend + backend + workers, with hot reload
+  pnpm build:oss      # full production build
+  pnpm lint           # prettier --check
+
+EOF

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,19 @@ SYNC_FREQUENCY='* * * * *'
 ALL_INCLUSIVE_ARCHIVE=false
 # Number of mailbox jobs that run concurrently in the ingestion worker. Increase on servers with more RAM.
 INGESTION_WORKER_CONCURRENCY=5
+# Emails processed concurrently WITHIN a single mailbox, so per-email database +
+# object-storage latency overlaps instead of running one-at-a-time. Set to 1 for
+# strictly serial processing. Defaults to 8.
+INGESTION_EMAIL_CONCURRENCY=8
+# UID window fetched per IMAP FETCH batch (envelope scan + body download).
+# Larger = fewer round-trips per mailbox, more memory per batch. Defaults to 250.
+IMAP_FETCH_BATCH_SIZE=250
+# Number of index-email-batch jobs the indexing worker runs concurrently.
+# Defaults to 1.
+INDEXING_WORKER_CONCURRENCY=1
+# Keyset page size for the reindex is_indexed reset scan (bounds each UPDATE so a
+# full-archive reindex never locks the whole table at once). Defaults to 5000.
+REINDEX_RESET_BATCH_SIZE=5000
 
 # --- Docker Compose Service Configuration ---
 # These variables are used by docker-compose.yml to configure the services. Leave them unchanged if you use Docker services for Postgresql, Valkey (Redis) and Meilisearch. If you decide to use your own instances of these services, you can substitute them with your own connection credentials.

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ IMAP_FETCH_BATCH_SIZE=250
 # Number of index-email-batch jobs the indexing worker runs concurrently.
 # Defaults to 1.
 INDEXING_WORKER_CONCURRENCY=1
+# Documents built concurrently within one index-email-batch job (each build reads
+# the .eml from storage and parses it, before the batch is written to Meilisearch
+# in a single request). Defaults to 10.
+INDEXING_DOCUMENT_BUILD_CONCURRENCY=10
 # Keyset page size for the reindex is_indexed reset scan (bounds each UPDATE so a
 # full-archive reindex never locks the whole table at once). Defaults to 5000.
 REINDEX_RESET_BATCH_SIZE=5000

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ dist
 
 # PNPM
 pnpm-debug.log
+# Repo-local pnpm store: pnpm falls back to this when its configured store is on
+# a different device than node_modules (e.g. the devcontainer bind mount).
+.pnpm-store/
 
 # IDE
 .vscode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working in this repository. The
+fastest, most reproducible way to develop here is the **devcontainer** — it
+brings up the app's backing services and a matching Node toolchain in one step.
+
+## TL;DR
+
+```bash
+# From the host, in the repo root:
+devcontainer up --workspace-folder .                 # build + start, runs post-create
+devcontainer exec --workspace-folder . pnpm db:migrate
+devcontainer exec --workspace-folder . pnpm dev:oss  # app + workers, hot reload
+```
+
+Frontend → http://localhost:3000 · Backend API → http://localhost:4000
+
+## Develop in the devcontainer
+
+The devcontainer (`.devcontainer/`) is a **Docker Compose** setup that layers a
+`dev` service (Node 22 + pnpm) on top of the project's existing backing services
+from the root `docker-compose.yml`, all on the `open-archiver-net` network.
+
+- **What starts:** `dev`, `postgres`, `valkey`, `meilisearch`, `tika`.
+  The production `open-archiver` container is intentionally **not** started
+  (`runServices` in `devcontainer.json`) — you run the app from source inside
+  `dev` instead.
+- **Reachability:** because `dev` shares the network, the app reaches
+  `postgres:5432`, `valkey:6379`, `meilisearch:7700`, and `tika:9998` by their
+  compose service names — exactly like the production container does. These are
+  the hostnames already baked into `.env`.
+- **First-run setup** (`.devcontainer/post-create.sh`, runs once): activates
+  pnpm `10.13.1` via corepack, seeds `.env` from `.env.example` if missing
+  (an existing `.env` is left untouched), runs `pnpm install`, and builds
+  `@open-archiver/types` so imports and `tsc` resolve immediately.
+
+### Two ways to drive it
+
+- **VS Code / Cursor:** "Reopen in Container". Ports 3000/4000 are forwarded
+  automatically; Prettier + Svelte + Vitest extensions are preinstalled.
+- **CLI (headless / agents):** use the `devcontainer` CLI from the host:
+
+  ```bash
+  devcontainer up --workspace-folder .                       # create/start
+  devcontainer exec --workspace-folder . <cmd>               # run a command inside
+  devcontainer up --workspace-folder . --remove-existing-container   # rebuild clean
+  ```
+
+  Run all `pnpm`/`node`/`tsc` commands **through `devcontainer exec`** so they
+  use the container's toolchain and can reach the services — not the host.
+
+### Devcontainer maintenance note
+
+Relative paths in the Compose files resolve against the Compose **project
+directory**, which the devcontainer CLI sets to the **repo root** (the first
+`-f` file's directory), *not* the `.devcontainer/` folder. That's why the `dev`
+service bind mount in `.devcontainer/docker-compose.yml` is `.:/workspaces/...`
+and **not** `..:` — the latter would mount the repo's parent directory. If you
+see the workspace contents look "one level too high," this is why.
+
+## Repo layout (pnpm workspace)
+
+| Path | What it is |
+|---|---|
+| `packages/backend` | API server + BullMQ workers, Drizzle ORM (Postgres), Meilisearch indexing, ingestion connectors |
+| `packages/frontend` | SvelteKit UI |
+| `packages/types` | Shared TypeScript types — **build this first**; backend/frontend import `@open-archiver/types` from its `dist` |
+| `apps/open-archiver` | OSS app entrypoint that wires the backend together |
+| `packages/enterprise` | Enterprise-only; **excluded** from OSS builds |
+
+Toolchain is pinned: Node `>=22`, pnpm `10.13.1` (`packageManager` field).
+
+## Common commands (run via `devcontainer exec`)
+
+```bash
+pnpm install                # install workspace deps
+pnpm --filter @open-archiver/types build   # build shared types (needed before typecheck)
+pnpm dev:oss                # frontend + backend + all workers, hot reload
+pnpm build:oss              # full OSS production build
+pnpm db:migrate             # apply DB schema (Drizzle); db:generate to create migrations
+pnpm lint                   # prettier --check .   (run before committing)
+pnpm format                 # prettier --write .
+```
+
+Background workers are part of the runtime (not just the API): the ingestion
+worker, indexing worker, and sync scheduler. `pnpm dev:oss` starts them
+(`start:workers:dev`); in production they run via `docker-start:oss`.
+
+## Architecture notes an agent should know
+
+- **Ingestion pipeline:** provider connectors (`packages/backend/src/services/
+  ingestion-connectors/` — IMAP, Google Workspace, M365, PST, EML, Mbox) yield
+  `EmailObject`s → `IngestionService.processEmail` (dedup gates, storage write,
+  DB insert) → BullMQ `ingestion` queue → `indexing` queue → Meilisearch. Jobs
+  are dispatched per-mailbox (`process-mailbox.processor.ts`).
+- **State stores:** Postgres (archived emails/attachments metadata, Drizzle),
+  object storage (raw `.eml` + attachments), Meilisearch (search index), Valkey
+  (BullMQ queues + cache), Tika (text extraction for indexing).
+- **Config:** all runtime config is env-driven, loaded from the repo-root `.env`
+  via `dotenv` at process start. `DATABASE_URL`, `REDIS_HOST`, `MEILI_HOST`,
+  `TIKA_URL` point at the compose service names.
+
+## Conventions
+
+- **TypeScript strict mode.** Avoid `any`; define shared shapes in
+  `packages/types`.
+- **Prettier** is the formatter — `pnpm lint` must pass before committing.
+- **Commits:** imperative present tense ("Add batch fetch", not "Added"), first
+  line ≤72 chars, reference issues/PRs after the first line. See
+  `CONTRIBUTING.md`.
+- **Tests:** there is currently **no test suite or runner** in this repo. If you
+  add tests, `vitest` fits the TS/ESM/pnpm stack best (the Vitest VS Code
+  extension is already listed in the devcontainer). Prefer unit-testing pure
+  logic and connector behavior with injected/mocked clients over hitting live
+  services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,14 @@ version: '3.8'
 
 services:
     open-archiver:
+        # `image` + `build` both set to the same tag: `docker compose up -d`
+        # (or `pull`) uses the published CI image, while `docker compose up -d
+        # --build` builds the local source tree and tags it over the same name.
+        # Lets you switch between pulling and building local changes freely.
         image: logiclabshq/open-archiver:latest
+        build:
+            context: .
+            dockerfile: apps/open-archiver/Dockerfile
         container_name: open-archiver
         restart: unless-stopped
         ports:

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,9 @@
 		"db:generate": "drizzle-kit generate --config=drizzle.config.ts",
 		"db:push": "drizzle-kit push --config=drizzle.config.ts",
 		"db:migrate": "node dist/database/migrate.js",
-		"db:migrate:dev": "ts-node-dev src/database/migrate.ts"
+		"db:migrate:dev": "ts-node-dev src/database/migrate.ts",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.844.0",
@@ -86,6 +88,7 @@
 		"swagger-jsdoc": "^6.2.8",
 		"ts-node-dev": "^2.0.0",
 		"tsconfig-paths": "^4.2.0",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"vitest": "^2.1.9"
 	}
 }

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -3,6 +3,7 @@ import { app } from './app';
 import { searchConfig, meiliConfig, indexingConfig } from './search';
 import { connection as redisConfig } from './redis';
 import { apiConfig } from './api';
+import { ingestionConfig } from './ingestion';
 
 export const config = {
 	storage,
@@ -10,6 +11,7 @@ export const config = {
 	search: searchConfig,
 	meili: meiliConfig,
 	indexing: indexingConfig,
+	ingestion: ingestionConfig,
 	redis: redisConfig,
 	api: apiConfig,
 };

--- a/packages/backend/src/config/ingestion.ts
+++ b/packages/backend/src/config/ingestion.ts
@@ -26,6 +26,10 @@ export const ingestionConfig = {
 	/** BullMQ indexing worker: how many index-email-batch jobs run at once. */
 	indexingWorkerConcurrency: intFromEnv('INDEXING_WORKER_CONCURRENCY', 1),
 
+	/** Documents built concurrently within one index-email-batch job (each build
+	 *  reads the .eml from storage + parses it). */
+	indexingDocumentBuildConcurrency: intFromEnv('INDEXING_DOCUMENT_BUILD_CONCURRENCY', 10),
+
 	/** Keyset page size for the reindex `is_indexed` reset scan. */
 	reindexResetBatchSize: intFromEnv('REINDEX_RESET_BATCH_SIZE', 5000),
 };

--- a/packages/backend/src/config/ingestion.ts
+++ b/packages/backend/src/config/ingestion.ts
@@ -1,0 +1,31 @@
+/** Parse a positive-integer env var, falling back to `fallback` when unset,
+ *  non-numeric, or <= 0. Keeps a bad value from silently zeroing a pool/batch. */
+const intFromEnv = (name: string, fallback: number): number => {
+	const raw = process.env[name];
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+/**
+ * Concurrency and batch-size tuning for the ingestion + indexing pipeline.
+ * All values are overridable via environment variables; the defaults preserve
+ * the previously hard-coded / inline behavior. See .env.example for docs.
+ */
+export const ingestionConfig = {
+	/** Emails processed concurrently within a single mailbox job, so per-email
+	 *  DB + object-storage latency overlaps. `1` = strictly serial. */
+	emailConcurrency: intFromEnv('INGESTION_EMAIL_CONCURRENCY', 8),
+
+	/** BullMQ ingestion worker: how many mailbox/import jobs run at once. */
+	workerConcurrency: intFromEnv('INGESTION_WORKER_CONCURRENCY', 5),
+
+	/** UID window fetched per IMAP FETCH batch (envelope scan + body fetch). */
+	imapFetchBatchSize: intFromEnv('IMAP_FETCH_BATCH_SIZE', 250),
+
+	/** BullMQ indexing worker: how many index-email-batch jobs run at once. */
+	indexingWorkerConcurrency: intFromEnv('INDEXING_WORKER_CONCURRENCY', 1),
+
+	/** Keyset page size for the reindex `is_indexed` reset scan. */
+	reindexResetBatchSize: intFromEnv('REINDEX_RESET_BATCH_SIZE', 5000),
+};

--- a/packages/backend/src/example.spec.ts
+++ b/packages/backend/src/example.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+
+// Smoke test confirming the vitest harness is wired up. Real unit tests live
+// alongside the code they cover as *.spec.ts (see vitest.config.ts include).
+describe('vitest harness', () => {
+	it('runs', () => {
+		expect(true).toBe(true);
+	});
+});

--- a/packages/backend/src/helpers/semaphore.spec.ts
+++ b/packages/backend/src/helpers/semaphore.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { Semaphore } from './semaphore';
+
+const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
+
+describe('Semaphore', () => {
+	it('never lets more than `permits` holders run concurrently', async () => {
+		const CONCURRENCY = 3;
+		const sem = new Semaphore(CONCURRENCY);
+		let active = 0;
+		let peak = 0;
+
+		const tasks = Array.from({ length: 20 }, () =>
+			(async () => {
+				await sem.acquire();
+				try {
+					active++;
+					peak = Math.max(peak, active);
+					await tick(5);
+				} finally {
+					active--;
+					sem.release();
+				}
+			})()
+		);
+
+		await Promise.all(tasks);
+		expect(peak).toBe(CONCURRENCY);
+		expect(active).toBe(0);
+	});
+
+	it('blocks acquire when saturated and resumes on release', async () => {
+		const sem = new Semaphore(1);
+		await sem.acquire(); // take the only permit
+
+		let acquired = false;
+		const pending = sem.acquire().then(() => {
+			acquired = true;
+		});
+
+		await tick(5);
+		expect(acquired).toBe(false); // still blocked
+
+		sem.release();
+		await pending;
+		expect(acquired).toBe(true);
+	});
+
+	it('hands permits to waiters in FIFO order', async () => {
+		const sem = new Semaphore(1);
+		await sem.acquire();
+
+		const order: number[] = [];
+		const w1 = sem.acquire().then(() => order.push(1));
+		const w2 = sem.acquire().then(() => order.push(2));
+		const w3 = sem.acquire().then(() => order.push(3));
+
+		sem.release();
+		await w1;
+		sem.release();
+		await w2;
+		sem.release();
+		await w3;
+
+		expect(order).toEqual([1, 2, 3]);
+	});
+
+	it('clamps invalid permit counts to at least 1', async () => {
+		const sem = new Semaphore(0);
+		await sem.acquire(); // would deadlock if permits were 0
+		expect(true).toBe(true);
+	});
+
+	it('draining by acquiring all permits waits for in-flight work', async () => {
+		const CONCURRENCY = 4;
+		const sem = new Semaphore(CONCURRENCY);
+		let done = 0;
+
+		for (let i = 0; i < 10; i++) {
+			await sem.acquire();
+			void (async () => {
+				try {
+					await tick(3);
+					done++;
+				} finally {
+					sem.release();
+				}
+			})();
+		}
+		// Drain: only possible once all in-flight tasks released their permit.
+		for (let i = 0; i < CONCURRENCY; i++) await sem.acquire();
+
+		expect(done).toBe(10);
+	});
+});

--- a/packages/backend/src/helpers/semaphore.ts
+++ b/packages/backend/src/helpers/semaphore.ts
@@ -1,0 +1,36 @@
+/**
+ * Minimal counting semaphore for bounding concurrency without a runtime
+ * dependency. `acquire()` resolves as soon as a permit is free; `release()`
+ * hands a permit straight to the next waiter (FIFO) or returns it to the pool.
+ *
+ * Usage: acquire before starting a task, release in its `finally`. To wait for
+ * all in-flight tasks to drain, acquire every permit — only possible once none
+ * are held.
+ */
+export class Semaphore {
+	private permits: number;
+	private readonly waiters: Array<() => void> = [];
+
+	constructor(permits: number) {
+		this.permits = Math.max(1, Math.floor(permits));
+	}
+
+	async acquire(): Promise<void> {
+		if (this.permits > 0) {
+			this.permits--;
+			return;
+		}
+		await new Promise<void>((resolve) => this.waiters.push(resolve));
+	}
+
+	release(): void {
+		const next = this.waiters.shift();
+		if (next) {
+			// Hand the permit directly to the next waiter without touching the
+			// counter, so no other acquire() can slip in ahead of them.
+			next();
+		} else {
+			this.permits++;
+		}
+	}
+}

--- a/packages/backend/src/jobs/helpers/resetIndexedFlag.ts
+++ b/packages/backend/src/jobs/helpers/resetIndexedFlag.ts
@@ -1,10 +1,12 @@
 import { and, asc, gt, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../database';
 import { archivedEmails } from '../../database/schema';
+import { config } from '../../config';
 
 /** Keyset page size for the reset scan. Bounds each UPDATE so no single statement
- *  locks the whole table on a full-archive reindex. */
-const RESET_BATCH_SIZE = 5000;
+ *  locks the whole table on a full-archive reindex. Override via
+ *  REINDEX_RESET_BATCH_SIZE. */
+const RESET_BATCH_SIZE = config.ingestion.reindexResetBatchSize;
 
 interface ResetOptions {
 	/** Scope filter (e.g. an ingestion-source group). Undefined = every archived email. */

--- a/packages/backend/src/jobs/processors/process-mailbox.processor.ts
+++ b/packages/backend/src/jobs/processors/process-mailbox.processor.ts
@@ -173,6 +173,20 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 			// flips the source to 'error', and the next scheduler tick launches a SECOND
 			// concurrent import that races this one and duplicates the archive.
 			if (Date.now() - lastHeartbeatAt >= HEARTBEAT_INTERVAL_MS) {
+				// Checkpoint progress so a mid-mailbox interruption (throttle/hang/
+				// restart) doesn't discard everything and force a re-scan from UID 1.
+				// Drain the in-flight pool FIRST so the checkpointed maxUid only covers
+				// durably-archived messages — acquiring every permit is only possible
+				// once all dispatched processEmail calls have released theirs.
+				for (let i = 0; i < CONCURRENCY; i++) await sem.acquire();
+				try {
+					await SyncSessionService.checkpointSyncState(
+						ingestionSourceId,
+						connector.getUpdatedSyncState(userEmail)
+					);
+				} finally {
+					for (let i = 0; i < CONCURRENCY; i++) sem.release();
+				}
 				await SyncSessionService.heartbeat(sessionId);
 				lastHeartbeatAt = Date.now();
 			}

--- a/packages/backend/src/jobs/processors/process-mailbox.processor.ts
+++ b/packages/backend/src/jobs/processors/process-mailbox.processor.ts
@@ -34,12 +34,23 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 		const connector = EmailProviderFactory.createConnector(source);
 		const ingestionService = new IngestionService();
 
+		// Resolve the merge-group source IDs ONCE per mailbox job. This value is
+		// stable for the whole run, so passing it into the per-email duplicate
+		// check and processEmail avoids re-running findGroupSourceIds (a DB query
+		// + credential decrypt + children query) on every single message.
+		const groupIds = await IngestionService.findGroupSourceIds(ingestionSourceId);
+
 		// Pre-check for duplicates without fetching full email content.
 		// Scoped to this specific mailbox (userEmail) so that different recipients
 		// of the same email each get their own archived row — only skipping when
 		// THIS mailbox already has the email (re-sync idempotency).
 		const checkDuplicate = async (messageId: string) => {
-			return await IngestionService.doesEmailExist(messageId, ingestionSourceId, userEmail);
+			return await IngestionService.doesEmailExist(
+				messageId,
+				ingestionSourceId,
+				userEmail,
+				groupIds
+			);
 		};
 
 		// Per-message accounting: processEmail returns a ProcessEmailError object on
@@ -67,7 +78,9 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 					email,
 					source,
 					storageService,
-					userEmail
+					userEmail,
+					false,
+					groupIds
 				);
 				if (processedEmail && 'error' in processedEmail) {
 					messagesFailed++;

--- a/packages/backend/src/jobs/processors/process-mailbox.processor.ts
+++ b/packages/backend/src/jobs/processors/process-mailbox.processor.ts
@@ -1,5 +1,10 @@
 import { Job } from 'bullmq';
-import { IProcessMailboxJob, ProcessMailboxError, PendingEmail } from '@open-archiver/types';
+import {
+	IProcessMailboxJob,
+	ProcessMailboxError,
+	PendingEmail,
+	ProcessEmailError,
+} from '@open-archiver/types';
 import { IngestionService } from '../../services/IngestionService';
 import { logger } from '../../config/logger';
 import { EmailProviderFactory } from '../../services/EmailProviderFactory';
@@ -7,6 +12,7 @@ import { StorageService } from '../../services/StorageService';
 import { config } from '../../config';
 import { indexingQueue, ingestionQueue } from '../queues';
 import { SyncSessionService } from '../../services/SyncSessionService';
+import { Semaphore } from '../../helpers/semaphore';
 
 /**
  * Handles ingestion of emails for a single user's mailbox.
@@ -67,6 +73,53 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 		const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 		let lastHeartbeatAt = Date.now();
 
+		// Process emails with bounded concurrency so per-email DB + object-storage
+		// latency overlaps instead of running strictly one-at-a-time (the batched
+		// IMAP fetch already removed the per-message network round-trip). The IMAP
+		// generator is still pulled sequentially — async generators are not safe to
+		// iterate concurrently — and each yielded email is dispatched to a pool
+		// capped at CONCURRENCY. Shared counters and emailBatch are only mutated
+		// from the settled callbacks below, which run one at a time on JS's single
+		// thread, so no locking is needed.
+		//
+		// Caveat: two DISTINCT new emails that share a Message-ID and land in the
+		// same concurrency window can both pass the dedup gates before either
+		// inserts (there is no unique constraint on message_id_header, only an
+		// index). This is rare — Pass 1 already filters already-archived dupes, so
+		// only brand-new messages reach here — and CONCURRENCY=1 restores the old
+		// strictly-serial behavior if it ever matters.
+		const CONCURRENCY = Math.max(
+			1,
+			parseInt(process.env.INGESTION_EMAIL_CONCURRENCY ?? '', 10) || 8
+		);
+		const sem = new Semaphore(CONCURRENCY);
+
+		const flushBatch = async () => {
+			if (emailBatch.length === 0) return;
+			// Capture + reset synchronously (no await between) so a concurrent
+			// completion can't push into a batch that is mid-flush.
+			const toFlush = emailBatch;
+			emailBatch = [];
+			await indexingQueue.add('index-email-batch', { emails: toFlush });
+		};
+
+		const handleResult = async (
+			result: PendingEmail | ProcessEmailError | null
+		): Promise<void> => {
+			if (result && 'error' in result) {
+				messagesFailed++;
+				if (failureSamples.length < MAX_FAILURE_SAMPLES) {
+					failureSamples.push(result.message);
+				}
+			} else if (result) {
+				messagesArchived++;
+				emailBatch.push(result);
+				if (emailBatch.length >= BATCH_SIZE) {
+					await flushBatch();
+				}
+			}
+		};
+
 		for await (const email of connector.fetchEmails(
 			userEmail,
 			source.syncState,
@@ -74,27 +127,34 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 		)) {
 			if (email) {
 				messagesSeen++;
-				const processedEmail = await ingestionService.processEmail(
-					email,
-					source,
-					storageService,
-					userEmail,
-					false,
-					groupIds
-				);
-				if (processedEmail && 'error' in processedEmail) {
-					messagesFailed++;
-					if (failureSamples.length < MAX_FAILURE_SAMPLES) {
-						failureSamples.push(processedEmail.message);
+				await sem.acquire();
+				// Detached: the pool bounds how many run at once; we drain below.
+				void (async () => {
+					try {
+						const result = await ingestionService.processEmail(
+							email,
+							source,
+							storageService,
+							userEmail,
+							false,
+							groupIds
+						);
+						await handleResult(result);
+					} catch (err) {
+						// processEmail is designed to RETURN a ProcessEmailError rather
+						// than throw; treat an unexpected throw as a per-message failure
+						// (count it, don't drop it silently — #403) instead of aborting
+						// the whole mailbox.
+						messagesFailed++;
+						if (failureSamples.length < MAX_FAILURE_SAMPLES) {
+							failureSamples.push(
+								`${email.id}: ${err instanceof Error ? err.message : 'unknown error'}`
+							);
+						}
+					} finally {
+						sem.release();
 					}
-				} else if (processedEmail) {
-					messagesArchived++;
-					emailBatch.push(processedEmail);
-					if (emailBatch.length >= BATCH_SIZE) {
-						await indexingQueue.add('index-email-batch', { emails: emailBatch });
-						emailBatch = [];
-					}
-				}
+				})();
 			}
 			// Heartbeat on wall-clock time, unconditionally. A single large mailbox can
 			// take hours, and long stretches legitimately archive nothing (dedup-skip
@@ -109,10 +169,13 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 			}
 		}
 
-		if (emailBatch.length > 0) {
-			await indexingQueue.add('index-email-batch', { emails: emailBatch });
-			emailBatch = [];
+		// Drain: acquiring every permit is only possible once all in-flight
+		// processEmail calls have released theirs.
+		for (let i = 0; i < CONCURRENCY; i++) {
+			await sem.acquire();
 		}
+
+		await flushBatch();
 
 		const newSyncState = connector.getUpdatedSyncState(userEmail);
 		logger.info(

--- a/packages/backend/src/jobs/processors/process-mailbox.processor.ts
+++ b/packages/backend/src/jobs/processors/process-mailbox.processor.ts
@@ -59,6 +59,17 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 			);
 		};
 
+		// Batched form of the above: connectors scanning large mailboxes dedup a
+		// whole envelope batch in ONE query instead of one per message.
+		const checkDuplicatesBatch = async (messageIds: string[]) => {
+			return await IngestionService.filterExistingMessageIds(
+				messageIds,
+				ingestionSourceId,
+				userEmail,
+				groupIds
+			);
+		};
+
 		// Per-message accounting: processEmail returns a ProcessEmailError object on
 		// genuine failures (parse/storage/DB) and null only for dedup skips. Failures
 		// must count towards the mailbox result — treating them as skips let imports
@@ -120,7 +131,8 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 		for await (const email of connector.fetchEmails(
 			userEmail,
 			source.syncState,
-			checkDuplicate
+			checkDuplicate,
+			checkDuplicatesBatch
 		)) {
 			if (email) {
 				messagesSeen++;

--- a/packages/backend/src/jobs/processors/process-mailbox.processor.ts
+++ b/packages/backend/src/jobs/processors/process-mailbox.processor.ts
@@ -88,10 +88,7 @@ export const processMailboxProcessor = async (job: Job<IProcessMailboxJob>) => {
 		// index). This is rare — Pass 1 already filters already-archived dupes, so
 		// only brand-new messages reach here — and CONCURRENCY=1 restores the old
 		// strictly-serial behavior if it ever matters.
-		const CONCURRENCY = Math.max(
-			1,
-			parseInt(process.env.INGESTION_EMAIL_CONCURRENCY ?? '', 10) || 8
-		);
+		const CONCURRENCY = config.ingestion.emailConcurrency;
 		const sem = new Semaphore(CONCURRENCY);
 
 		const flushBatch = async () => {

--- a/packages/backend/src/services/EmailProviderFactory.ts
+++ b/packages/backend/src/services/EmailProviderFactory.ts
@@ -35,7 +35,11 @@ export interface IEmailConnector {
 	fetchEmails(
 		userEmail: string,
 		syncState?: SyncState | null,
-		checkDuplicate?: (messageId: string) => Promise<boolean>
+		checkDuplicate?: (messageId: string) => Promise<boolean>,
+		// Optional batched pre-check: given many candidate message-ids, returns the
+		// subset already archived. Connectors that scan large mailboxes (IMAP) use
+		// this to dedup a whole batch in one DB query; others keep checkDuplicate.
+		checkDuplicatesBatch?: (messageIds: string[]) => Promise<Set<string>>
 	): AsyncGenerator<EmailObject | null>;
 	getUpdatedSyncState(userEmail?: string): SyncState;
 	listAllUsers(): AsyncGenerator<MailboxUser>;

--- a/packages/backend/src/services/IndexingService.ts
+++ b/packages/backend/src/services/IndexingService.ts
@@ -14,6 +14,7 @@ import { eq, inArray, sql } from 'drizzle-orm';
 import { streamToBuffer } from '../helpers/streamToBuffer';
 import { simpleParser, type Attachment as ParsedAttachment } from 'mailparser';
 import { logger } from '../config/logger';
+import { config } from '../config';
 
 interface DbRecipients {
 	to: { name: string; address: string }[];
@@ -85,7 +86,7 @@ export class IndexingService {
 
 		logger.info({ batchSize: emails.length }, 'Starting batch indexing of emails');
 
-		const CONCURRENCY_LIMIT = 10;
+		const CONCURRENCY_LIMIT = config.ingestion.indexingDocumentBuildConcurrency;
 		const rawDocuments: EmailDocument[] = [];
 		// Emails whose document could not be BUILT (corrupt EML, parse error, etc.).
 		// These are email-specific ("poison") failures — increment index_attempts so

--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -779,13 +779,16 @@ export class IngestionService {
 	public static async doesEmailExist(
 		messageId: string,
 		ingestionSourceId: string,
-		userEmail: string
+		userEmail: string,
+		groupIds?: string[]
 	): Promise<boolean> {
-		const groupIds = await this.findGroupSourceIds(ingestionSourceId);
+		// Callers processing many messages for one source can pass a precomputed
+		// merge-group id list to avoid re-resolving it (DB + decrypt) per message.
+		const resolvedGroupIds = groupIds ?? (await this.findGroupSourceIds(ingestionSourceId));
 		const sourceFilter =
-			groupIds.length === 1
-				? eq(archivedEmails.ingestionSourceId, groupIds[0])
-				: inArray(archivedEmails.ingestionSourceId, groupIds);
+			resolvedGroupIds.length === 1
+				? eq(archivedEmails.ingestionSourceId, resolvedGroupIds[0])
+				: inArray(archivedEmails.ingestionSourceId, resolvedGroupIds);
 
 		const existingEmail = await db.query.archivedEmails.findFirst({
 			where: and(
@@ -888,6 +891,10 @@ export class IngestionService {
 	 *   email.tempFilePath. Used by the journaling fan-out loop which calls
 	 *   processEmail() multiple times with the same EmailObject — only the last
 	 *   caller should clean up the temp file.
+	 * @param precomputedGroupIds Optional merge-group source IDs resolved once by the
+	 *   caller (e.g. the process-mailbox loop) so this method doesn't re-run
+	 *   findGroupSourceIds (a DB query + credential decrypt + children query) on
+	 *   every message. Must be the group of `source.id`.
 	 * @returns The pending email on success, `null` when the email was deduplicated /
 	 *   intentionally skipped, or a ProcessEmailError when archiving failed. Callers must
 	 *   count error returns towards their failure totals — treating them as skips is what
@@ -898,7 +905,8 @@ export class IngestionService {
 		source: IngestionSource,
 		storage: StorageService,
 		userEmail: string,
-		skipTempFileCleanup: boolean = false
+		skipTempFileCleanup: boolean = false,
+		precomputedGroupIds?: string[]
 	): Promise<PendingEmail | ProcessEmailError | null> {
 		try {
 			// Read the raw bytes from the temp file written by the connector
@@ -935,7 +943,8 @@ export class IngestionService {
 			//         in the group. Write file + create row.
 			// ─────────────────────────────────────────────────────────────────
 
-			const groupIds = await IngestionService.findGroupSourceIds(source.id);
+			const groupIds =
+				precomputedGroupIds ?? (await IngestionService.findGroupSourceIds(source.id));
 			const groupSourceFilter =
 				groupIds.length === 1
 					? eq(archivedEmails.ingestionSourceId, groupIds[0])

--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -805,6 +805,65 @@ export class IngestionService {
 	}
 
 	/**
+	 * Batched form of doesEmailExist for the ingestion pre-check: given many
+	 * candidate message-ids, return the subset that already exists for this
+	 * mailbox in a SINGLE query, instead of one findFirst per id. This collapses
+	 * the per-message dedup round-trips during the envelope scan (the dominant
+	 * cost of re-scanning an already-archived mailbox) into one query per batch.
+	 * A message-id matches on either providerMessageId or messageIdHeader,
+	 * scoped to the merge group + userEmail — identical predicate to
+	 * doesEmailExist, just set-based.
+	 */
+	public static async filterExistingMessageIds(
+		messageIds: string[],
+		ingestionSourceId: string,
+		userEmail: string,
+		groupIds?: string[]
+	): Promise<Set<string>> {
+		const existing = new Set<string>();
+		if (messageIds.length === 0) {
+			return existing;
+		}
+
+		const resolvedGroupIds = groupIds ?? (await this.findGroupSourceIds(ingestionSourceId));
+		const sourceFilter =
+			resolvedGroupIds.length === 1
+				? eq(archivedEmails.ingestionSourceId, resolvedGroupIds[0])
+				: inArray(archivedEmails.ingestionSourceId, resolvedGroupIds);
+
+		const rows = await db
+			.select({
+				providerMessageId: archivedEmails.providerMessageId,
+				messageIdHeader: archivedEmails.messageIdHeader,
+			})
+			.from(archivedEmails)
+			.where(
+				and(
+					sourceFilter,
+					eq(archivedEmails.userEmail, userEmail),
+					or(
+						inArray(archivedEmails.providerMessageId, messageIds),
+						inArray(archivedEmails.messageIdHeader, messageIds)
+					)
+				)
+			);
+
+		// A matched row carries both columns; only one necessarily matched the IN
+		// clause, so intersect with the requested ids to return exactly the input
+		// message-ids that exist.
+		const requested = new Set(messageIds);
+		for (const row of rows) {
+			if (row.providerMessageId && requested.has(row.providerMessageId)) {
+				existing.add(row.providerMessageId);
+			}
+			if (row.messageIdHeader && requested.has(row.messageIdHeader)) {
+				existing.add(row.messageIdHeader);
+			}
+		}
+		return existing;
+	}
+
+	/**
 	 * Builds the filesystem-safe filename component for an email's .eml from its id.
 	 * The provider id / Message-ID becomes an actual filename, but Exchange-style ids can
 	 * exceed the 255-byte filename limit or contain '/', producing ENAMETOOLONG / bad-path

--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -652,6 +652,15 @@ export class IngestionService {
 			}
 		}
 
+		// Force sync is a deliberate, user-initiated full re-import: clear the
+		// stored sync_state (maxUid) so the scan restarts from the beginning
+		// instead of resuming from the last incremental checkpoint.
+		await db
+			.update(ingestionSources)
+			.set({ syncState: null })
+			.where(eq(ingestionSources.id, id));
+		logger.info({ ingestionSourceId: id }, 'Cleared sync state for force sync (full re-scan).');
+
 		// Reset status to 'active'
 		await this.update(
 			id,
@@ -697,6 +706,11 @@ export class IngestionService {
 						{ childId: child.id, parentId: id },
 						'Cascading force sync to child source.'
 					);
+					// Match the root: clear the child's sync_state so it re-scans fully.
+					await db
+						.update(ingestionSources)
+						.set({ syncState: null })
+						.where(eq(ingestionSources.id, child.id));
 					await ingestionQueue.add('continuous-sync', { ingestionSourceId: child.id });
 				}
 			}

--- a/packages/backend/src/services/SyncSessionService.ts
+++ b/packages/backend/src/services/SyncSessionService.ts
@@ -137,6 +137,37 @@ export class SyncSessionService {
 	}
 
 	/**
+	 * Mid-job checkpoint: merge a partial SyncState (e.g. the current maxUid) into
+	 * the ingestion source's sync_state column, using the same jsonb || merge as
+	 * recordMailboxResult but without touching session counters. Lets a long
+	 * mailbox persist progress incrementally, so an interruption (throttle/hang)
+	 * before completion doesn't discard everything and force a re-scan from UID 1.
+	 *
+	 * The caller MUST ensure the checkpointed state only covers durably-archived
+	 * messages (see process-mailbox.processor: it drains in-flight work first).
+	 */
+	public static async checkpointSyncState(
+		ingestionSourceId: string,
+		syncState: SyncState
+	): Promise<void> {
+		if (!syncState || Object.keys(syncState).length === 0) {
+			return;
+		}
+		try {
+			await db
+				.update(ingestionSources)
+				.set({
+					syncState: sql`COALESCE(${ingestionSources.syncState}, '{}'::jsonb) || ${JSON.stringify(syncState)}::jsonb`,
+				})
+				.where(eq(ingestionSources.id, ingestionSourceId));
+		} catch (error) {
+			// Non-fatal: a missed checkpoint just means the next one (or job
+			// completion) persists progress. Don't let it fail the mailbox.
+			logger.warn({ err: error, ingestionSourceId }, 'Failed to checkpoint sync state');
+		}
+	}
+
+	/**
 	 * Fetches a sync session by its ID.
 	 */
 	public static async findById(sessionId: string): Promise<SyncSessionRecord> {

--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.spec.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { unlink } from 'fs/promises';
+import type { ImapFlow } from 'imapflow';
+import type { GenericImapCredentials } from '@open-archiver/types';
+import { ImapConnector } from './ImapConnector';
+
+// Fixture mailbox: three messages, one of which (uid 102) the caller reports as
+// an already-archived duplicate so it must be skipped before its body is fetched.
+const MESSAGES = [
+	{ uid: 101, messageId: '<m1@example.com>', subject: 'Test 1' },
+	{ uid: 102, messageId: '<m2@example.com>', subject: 'Test 2' },
+	{ uid: 103, messageId: '<m3@example.com>', subject: 'Test 3' },
+];
+
+const rawEmail = (m: { messageId: string; subject: string }): Buffer =>
+	Buffer.from(
+		`From: sender@example.com\r\n` +
+			`To: rcpt@example.com\r\n` +
+			`Subject: ${m.subject}\r\n` +
+			`Message-ID: ${m.messageId}\r\n` +
+			`Date: Wed, 01 Jan 2025 00:00:00 +0000\r\n` +
+			`\r\n` +
+			`Body of ${m.subject}\r\n`
+	);
+
+interface Recorder {
+	fetchOneCalls: string[];
+	envelopeFetchRanges: unknown[];
+	sourceFetchRanges: unknown[];
+}
+
+/**
+ * Minimal fake ImapFlow that records how bodies are fetched. `usable` returns
+ * true so the connector's connect() keeps this instance rather than building a
+ * real client. `fetch()` branches on whether the query asks for `source`:
+ * Pass 1 (envelopes only) yields every message; Pass 2 (with source) yields only
+ * the UIDs requested in the ranged set.
+ */
+const makeFakeClient = (recorder: Recorder): ImapFlow =>
+	({
+		get usable() {
+			return true;
+		},
+		async connect() {},
+		async logout() {},
+		on() {},
+		async list() {
+			return [{ path: 'INBOX', flags: new Set<string>(), specialUse: undefined }];
+		},
+		async mailboxOpen(path: string) {
+			return { path, exists: MESSAGES.length };
+		},
+		async fetchOne(seq: string) {
+			// Only used to seed the max UID from the last message in the mailbox.
+			recorder.fetchOneCalls.push(seq);
+			return { uid: MESSAGES[MESSAGES.length - 1].uid };
+		},
+		fetch(range: { uid?: string }, query: { source?: boolean }) {
+			const isSource = !!query?.source;
+			(isSource ? recorder.sourceFetchRanges : recorder.envelopeFetchRanges).push(range?.uid);
+			async function* gen() {
+				const wanted = isSource
+					? String(range?.uid ?? '')
+							.split(',')
+							.map((s) => parseInt(s, 10))
+					: null;
+				for (const m of MESSAGES) {
+					if (wanted && !wanted.includes(m.uid)) continue;
+					yield isSource
+						? { uid: m.uid, envelope: { messageId: m.messageId }, source: rawEmail(m) }
+						: { uid: m.uid, envelope: { messageId: m.messageId } };
+				}
+			}
+			return gen();
+		},
+	}) as unknown as ImapFlow;
+
+const credentials: GenericImapCredentials = {
+	type: 'generic_imap',
+	host: 'imap.example.com',
+	port: 993,
+	secure: true,
+	allowInsecureCert: false,
+	username: 'user@example.com',
+	password: 'secret',
+};
+
+describe('ImapConnector.fetchEmails batching', () => {
+	it('fetches all non-duplicate message bodies in a single ranged FETCH', async () => {
+		const recorder: Recorder = {
+			fetchOneCalls: [],
+			envelopeFetchRanges: [],
+			sourceFetchRanges: [],
+		};
+		const connector = new ImapConnector(credentials, { preserveOriginalFile: false }, () =>
+			makeFakeClient(recorder)
+		);
+
+		// uid 102 (<m2@example.com>) is reported as already archived.
+		const checkDuplicate = vi.fn(async (mid: string) => mid === '<m2@example.com>');
+
+		const collected = [];
+		for await (const email of connector.fetchEmails('user@example.com', null, checkDuplicate)) {
+			if (email) collected.push(email);
+		}
+
+		try {
+			// THE regression guard: bodies are pulled in ONE batched FETCH over the
+			// non-duplicate UID set — not one FETCH command per message.
+			expect(recorder.sourceFetchRanges).toEqual(['101,103']);
+
+			// fetchOne is used only to seed the max UID (the mailbox.exists index),
+			// never to download message bodies.
+			expect(recorder.fetchOneCalls).toEqual(['3']);
+
+			// Both non-duplicates were parsed and yielded; the duplicate was skipped
+			// (and never had its body fetched).
+			expect(collected.map((e) => e.subject).sort()).toEqual(['Test 1', 'Test 3']);
+			expect(checkDuplicate).toHaveBeenCalledTimes(MESSAGES.length);
+
+			// Sync state advances to the highest UID observed.
+			expect(connector.getUpdatedSyncState().imap?.['INBOX']?.maxUid).toBe(103);
+		} finally {
+			await Promise.all(collected.map((e) => unlink(e.tempFilePath).catch(() => {})));
+		}
+	});
+
+	it('skips the body FETCH entirely when every message is a duplicate', async () => {
+		const recorder: Recorder = {
+			fetchOneCalls: [],
+			envelopeFetchRanges: [],
+			sourceFetchRanges: [],
+		};
+		const connector = new ImapConnector(credentials, { preserveOriginalFile: false }, () =>
+			makeFakeClient(recorder)
+		);
+
+		const checkDuplicate = vi.fn(async () => true);
+
+		const collected = [];
+		for await (const email of connector.fetchEmails('user@example.com', null, checkDuplicate)) {
+			if (email) collected.push(email);
+		}
+
+		// No non-duplicates → Pass 2 never issues a source FETCH, nothing yielded.
+		expect(recorder.sourceFetchRanges).toEqual([]);
+		expect(collected).toHaveLength(0);
+		// Envelopes were still scanned and max UID still advances.
+		expect(connector.getUpdatedSyncState().imap?.['INBOX']?.maxUid).toBe(103);
+	});
+});

--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.spec.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.spec.ts
@@ -148,4 +148,50 @@ describe('ImapConnector.fetchEmails batching', () => {
 		// Envelopes were still scanned and max UID still advances.
 		expect(connector.getUpdatedSyncState().imap?.['INBOX']?.maxUid).toBe(103);
 	});
+
+	it('dedups the whole batch in ONE call when a batch checker is provided', async () => {
+		const recorder: Recorder = {
+			fetchOneCalls: [],
+			envelopeFetchRanges: [],
+			sourceFetchRanges: [],
+		};
+		const connector = new ImapConnector(credentials, { preserveOriginalFile: false }, () =>
+			makeFakeClient(recorder)
+		);
+
+		// Per-message checker must NOT be used when a batch checker is present.
+		const checkDuplicate = vi.fn(async () => false);
+		const checkDuplicatesBatch = vi.fn(
+			async (_ids: string[]) => new Set<string>(['<m2@example.com>'])
+		);
+
+		const collected = [];
+		for await (const email of connector.fetchEmails(
+			'user@example.com',
+			null,
+			checkDuplicate,
+			checkDuplicatesBatch
+		)) {
+			if (email) collected.push(email);
+		}
+
+		try {
+			// Dedup is a SINGLE call for the batch, given every message-id.
+			expect(checkDuplicatesBatch).toHaveBeenCalledTimes(1);
+			expect(checkDuplicatesBatch.mock.calls[0][0].sort()).toEqual([
+				'<m1@example.com>',
+				'<m2@example.com>',
+				'<m3@example.com>',
+			]);
+			// The per-message checker is bypassed entirely.
+			expect(checkDuplicate).not.toHaveBeenCalled();
+
+			// Batch-flagged duplicate (<m2>) skipped; the other two fetched in one
+			// ranged source FETCH.
+			expect(recorder.sourceFetchRanges).toEqual(['101,103']);
+			expect(collected.map((e) => e.subject).sort()).toEqual(['Test 1', 'Test 3']);
+		} finally {
+			await Promise.all(collected.map((e) => unlink(e.tempFilePath).catch(() => {})));
+		}
+	});
 });

--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
@@ -18,16 +18,25 @@ export class ImapConnector implements IEmailConnector {
 	private newMaxUids: { [mailboxPath: string]: number } = {};
 	private statusMessage: string | undefined;
 	private options: ConnectorOptions;
+	// Test seam: when provided, client creation is delegated to this factory
+	// instead of constructing a real ImapFlow. Also used by connect()'s
+	// rebuild path, so retries get a fresh injected client. Undefined in prod.
+	private clientFactory?: () => ImapFlow;
 
 	constructor(
 		private credentials: GenericImapCredentials,
-		options?: ConnectorOptions
+		options?: ConnectorOptions,
+		clientFactory?: () => ImapFlow
 	) {
 		this.options = options ?? { preserveOriginalFile: false };
+		this.clientFactory = clientFactory;
 		this.client = this.createClient();
 	}
 
 	private createClient(): ImapFlow {
+		if (this.clientFactory) {
+			return this.clientFactory();
+		}
 		const client = new ImapFlow({
 			host: this.credentials.host,
 			port: this.credentials.port,
@@ -251,37 +260,103 @@ export class ImapConnector implements IEmailConnector {
 								}
 							}
 
-							// --- Pass 2: fetch full source one message at a time for non-duplicate UIDs.
-							for (const uid of uidsToFetch) {
-								logger.debug(
-									{ mailboxPath, uid },
-									'Fetching full source for message'
-								);
+							// --- Pass 2: bulk-fetch full source for all non-duplicate UIDs in a
+							// SINGLE ranged IMAP FETCH (pipelined by the server) instead of one
+							// FETCH command per message — the previous per-message round-trip was
+							// the dominant ingest bottleneck. Stream + yield as each arrives so the
+							// heap stays bounded to one message (matches the temp-file design). On
+							// a mid-stream disconnect, reconnect and re-fetch only the UIDs not yet
+							// yielded, preserving the previous per-message retry robustness.
+							if (uidsToFetch.length > 0) {
+								const yielded = new Set<number>();
+								const maxRetries = 5;
+								let attempt = 0;
 
-								try {
-									const fullMsg = await this.withRetry(
-										async () =>
-											await this.client.fetchOne(
-												String(uid),
-												{
-													envelope: true,
-													source: true,
-													bodyStructure: true,
-													uid: true,
-												},
-												{ uid: true }
-											)
-									);
-
-									if (fullMsg && fullMsg.envelope && fullMsg.source) {
-										yield await this.parseMessage(fullMsg, mailboxPath);
+								while (true) {
+									const remaining = uidsToFetch.filter((u) => !yielded.has(u));
+									if (remaining.length === 0) {
+										break;
 									}
-								} catch (err: any) {
-									logger.error(
-										{ err, mailboxPath, uid },
-										'Failed to fetch or parse message'
-									);
-									throw err;
+
+									// Set only when parseMessage (not the network) throws, so a bad
+									// message aborts the mailbox instead of being retried as if it
+									// were a transient fetch failure.
+									let parseError: unknown = null;
+
+									try {
+										await this.connect();
+										logger.debug(
+											{ mailboxPath, count: remaining.length },
+											'Bulk-fetching full source for non-duplicate messages'
+										);
+
+										for await (const fullMsg of this.client.fetch(
+											{ uid: remaining.join(',') },
+											{
+												envelope: true,
+												source: true,
+												bodyStructure: true,
+												uid: true,
+											}
+										)) {
+											// Mark received BEFORE parsing so a reconnect never
+											// re-fetches or double-yields this message.
+											if (fullMsg?.uid) {
+												yielded.add(fullMsg.uid);
+											}
+
+											if (fullMsg && fullMsg.envelope && fullMsg.source) {
+												let parsed: EmailObject;
+												try {
+													parsed = await this.parseMessage(
+														fullMsg,
+														mailboxPath
+													);
+												} catch (err) {
+													parseError = err;
+													break;
+												}
+												yield parsed;
+											}
+										}
+									} catch (err: any) {
+										// Network/stream error → reconnect and retry only the
+										// still-unyielded UIDs with exponential backoff + jitter.
+										attempt++;
+										logger.error(
+											{ err, mailboxPath, attempt },
+											`Bulk source fetch failed on attempt ${attempt}`
+										);
+										if (attempt >= maxRetries) {
+											logger.error(
+												{ err, mailboxPath },
+												'Bulk source fetch failed after all retries.'
+											);
+											throw err;
+										}
+										const delay = Math.pow(2, attempt) * 1000;
+										const jitter = Math.random() * 1000;
+										logger.info(
+											`Retrying bulk fetch in ${Math.round(
+												(delay + jitter) / 1000
+											)}s`
+										);
+										await new Promise((resolve) =>
+											setTimeout(resolve, delay + jitter)
+										);
+										continue;
+									}
+
+									// Stream drained without a network error. A parseMessage
+									// failure is fatal for the mailbox (matches prior behavior).
+									if (parseError) {
+										logger.error(
+											{ err: parseError, mailboxPath },
+											'Failed to parse message'
+										);
+										throw parseError;
+									}
+									break;
 								}
 							}
 

--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
@@ -212,7 +212,7 @@ export class ImapConnector implements IEmailConnector {
 
 					// Only fetch if the mailbox has messages, to avoid errors on empty mailboxes with some IMAP servers.
 					if (mailbox.exists > 0) {
-						const BATCH_SIZE = 250;
+						const BATCH_SIZE = config.ingestion.imapFetchBatchSize;
 						let startUid = (lastUid || 0) + 1;
 						const maxUidToFetch = currentMaxUid;
 

--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
@@ -158,7 +158,8 @@ export class ImapConnector implements IEmailConnector {
 	public async *fetchEmails(
 		userEmail: string,
 		syncState?: SyncState | null,
-		checkDuplicate?: (messageId: string) => Promise<boolean>
+		checkDuplicate?: (messageId: string) => Promise<boolean>,
+		checkDuplicatesBatch?: (messageIds: string[]) => Promise<Set<string>>
 	): AsyncGenerator<EmailObject | null> {
 		try {
 			// list all mailboxes first
@@ -220,8 +221,14 @@ export class ImapConnector implements IEmailConnector {
 							const endUid = Math.min(startUid + BATCH_SIZE - 1, maxUidToFetch);
 							const searchCriteria = { uid: `${startUid}:${endUid}` };
 
-							// --- Pass 1: fetch only envelope + uid (no source) for the entire batch.
+							// --- Pass 1: fetch only envelope + uid (no source) for the entire
+							// batch, collecting candidates first so duplicates can be checked
+							// in ONE query (checkDuplicatesBatch) rather than one per message
+							// — the per-message round-trip dominated re-scans of an
+							// already-archived mailbox. Falls back to the per-message
+							// checkDuplicate when no batch checker is supplied.
 							const uidsToFetch: number[] = [];
+							const candidates: Array<{ uid: number; messageId?: string }> = [];
 
 							for await (const msg of this.client.fetch(searchCriteria, {
 								envelope: true,
@@ -235,29 +242,48 @@ export class ImapConnector implements IEmailConnector {
 									this.newMaxUids[mailboxPath] = msg.uid;
 								}
 
-								// Duplicate check against the Message-ID from the envelope.
-								// If a duplicate is found we skip fetching the full source entirely,
-								// avoiding loading attachment binary data into memory for known emails.
-								if (checkDuplicate && msg.envelope?.messageId) {
-									const isDuplicate = await checkDuplicate(
-										msg.envelope.messageId
-									);
+								if (msg.envelope) {
+									candidates.push({
+										uid: msg.uid,
+										messageId: msg.envelope.messageId ?? undefined,
+									});
+								}
+							}
+
+							// One batched dedup lookup for the whole envelope batch, when
+							// available. A duplicate is skipped so its full source (and any
+							// attachment binary) is never fetched.
+							let existingIds: Set<string> | null = null;
+							if (checkDuplicatesBatch) {
+								const ids = candidates
+									.map((c) => c.messageId)
+									.filter((id): id is string => !!id);
+								existingIds =
+									ids.length > 0
+										? await checkDuplicatesBatch(ids)
+										: new Set<string>();
+							}
+
+							for (const candidate of candidates) {
+								if (candidate.messageId) {
+									const isDuplicate = existingIds
+										? existingIds.has(candidate.messageId)
+										: checkDuplicate
+											? await checkDuplicate(candidate.messageId)
+											: false;
 									if (isDuplicate) {
 										logger.debug(
 											{
 												mailboxPath,
-												uid: msg.uid,
-												messageId: msg.envelope.messageId,
+												uid: candidate.uid,
+												messageId: candidate.messageId,
 											},
 											'Skipping duplicate email (pre-check)'
 										);
 										continue;
 									}
 								}
-
-								if (msg.envelope) {
-									uidsToFetch.push(msg.uid);
-								}
+								uidsToFetch.push(candidate.uid);
 							}
 
 							// --- Pass 2: bulk-fetch full source for all non-duplicate UIDs in a

--- a/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
+++ b/packages/backend/src/services/ingestion-connectors/ImapConnector.ts
@@ -238,10 +238,11 @@ export class ImapConnector implements IEmailConnector {
 									continue;
 								}
 
-								if (msg.uid > this.newMaxUids[mailboxPath]) {
-									this.newMaxUids[mailboxPath] = msg.uid;
-								}
-
+								// NB: the checkpointable maxUid is advanced at batch-end
+								// (below), NOT here per-envelope — advancing it during the
+								// Pass 1 scan would let a mid-job checkpoint report a UID
+								// whose body hasn't been fetched/archived yet, causing the
+								// next resume to skip it.
 								if (msg.envelope) {
 									candidates.push({
 										uid: msg.uid,
@@ -385,6 +386,14 @@ export class ImapConnector implements IEmailConnector {
 									break;
 								}
 							}
+
+							// This batch is fully scanned and its non-duplicate bodies have
+							// all been yielded: advance the checkpointable high-water mark to
+							// the batch's upper bound. Every UID <= endUid is now either
+							// yielded for archival or a confirmed duplicate, so a mid-job
+							// checkpoint of this value is safe (once the consumer has drained
+							// its in-flight archival work).
+							this.newMaxUids[mailboxPath] = endUid;
 
 							// Move to the next batch
 							startUid = endUid + 1;

--- a/packages/backend/src/workers/indexing.worker.ts
+++ b/packages/backend/src/workers/indexing.worker.ts
@@ -1,5 +1,6 @@
 import { Worker } from 'bullmq';
 import { connection } from '../config/redis';
+import { config } from '../config';
 import indexEmailBatchProcessor from '../jobs/processors/index-email-batch.processor';
 import reindexProcessor from '../jobs/processors/reindex.processor';
 import reconcileIndexProcessor from '../jobs/processors/reconcile-index.processor';
@@ -20,6 +21,9 @@ const processor = async (job: any) => {
 
 const worker = new Worker('indexing', processor, {
 	connection,
+	// Configurable via INDEXING_WORKER_CONCURRENCY env var (default 1, matching
+	// BullMQ's previous implicit default).
+	concurrency: config.ingestion.indexingWorkerConcurrency,
 	removeOnComplete: {
 		count: 100, // keep last 100 jobs
 	},

--- a/packages/backend/src/workers/ingestion.worker.ts
+++ b/packages/backend/src/workers/ingestion.worker.ts
@@ -1,5 +1,6 @@
 import { Worker } from 'bullmq';
 import { connection } from '../config/redis';
+import { config } from '../config';
 import initialImportProcessor from '../jobs/processors/initial-import.processor';
 import continuousSyncProcessor from '../jobs/processors/continuous-sync.processor';
 import scheduleContinuousSyncProcessor from '../jobs/processors/schedule-continuous-sync.processor';
@@ -27,9 +28,7 @@ const processor = async (job: any) => {
 const worker = new Worker('ingestion', processor, {
 	connection,
 	// Configurable via INGESTION_WORKER_CONCURRENCY env var. Tune based on available RAM.
-	concurrency: process.env.INGESTION_WORKER_CONCURRENCY
-		? parseInt(process.env.INGESTION_WORKER_CONCURRENCY, 10)
-		: 5,
+	concurrency: config.ingestion.workerConcurrency,
 	// Connector work (pst-extractor parsing, attachment reads, EML construction) is
 	// largely synchronous, and one huge message can block the event loop long enough
 	// that the automatic lock renewal (every lockDuration/2) misses its window. With

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -8,7 +8,7 @@
 		"composite": true
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["node_modules", "dist"],
+	"exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
 	"references": [
 		{
 			"path": "../types"

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// Unit tests run in Node and may touch the real filesystem (temp files),
+		// but must not require the live Postgres/Valkey/Meili/Tika services.
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.ts'],
+		// Sets minimal env before the config module graph loads (see file).
+		setupFiles: ['./vitest.setup.ts'],
+		// Keep the default 5s per-test timeout; these are pure/mocked unit tests.
+	},
+});

--- a/packages/backend/vitest.setup.ts
+++ b/packages/backend/vitest.setup.ts
@@ -1,0 +1,7 @@
+// Minimal env so the config module graph loads during unit tests without a real
+// .env or live services. `||=` leaves any real value in place. These unit tests
+// never touch storage/DB/search — they only need config import to succeed.
+process.env.STORAGE_TYPE ||= 'local';
+process.env.STORAGE_LOCAL_ROOT_PATH ||= '/tmp/oa-test-storage';
+// 64-char hex (32 bytes), validated by config/storage.ts.
+process.env.STORAGE_ENCRYPTION_KEY ||= '0'.repeat(64);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@24.0.13)(lightningcss@1.30.1)
 
   packages/frontend:
     dependencies:
@@ -683,11 +686,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1953,6 +1956,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -1960,6 +1964,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vue/compiler-core@3.5.18':
     resolution: {integrity: sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==}
@@ -2065,6 +2098,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -2161,6 +2195,10 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -2271,6 +2309,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
@@ -2289,6 +2331,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2298,6 +2344,10 @@ packages:
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2587,6 +2637,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -2835,6 +2889,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2879,6 +2936,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2898,6 +2958,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.0.1:
     resolution: {integrity: sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==}
@@ -3474,6 +3538,9 @@ packages:
   lop@0.4.2:
     resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3483,11 +3550,13 @@ packages:
 
   lucide-svelte@0.525.0:
     resolution: {integrity: sha512-kfuN6JcCqTfCz2B76aXnyGLAzEBRSYw5GaUspM5RNHQZS5aI5yaKu06fbaofOk8cDvUtY0AUm/zAix7aUX6Q3A==}
+    deprecated: Package deprecated. Please use @lucide/svelte instead.
     peerDependencies:
       svelte: ^3 || ^4 || ^5.0.0-next.42
 
   lucide-vue-next@0.577.0:
     resolution: {integrity: sha512-py05bAfv9SHVJqscbiOnjcnLlEmOffA58a+7XhZuFxrs6txe1E8VoR1ngWGTYO+9aVKABAz8l3ee3PqiQN9QPA==}
+    deprecated: Package deprecated. Please use @lucide/vue instead.
     peerDependencies:
       vue: '>=3.0.1'
 
@@ -3842,11 +3911,17 @@ packages:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pdf2json@3.1.6:
     resolution: {integrity: sha512-Nkwo9qeCvqVH0ZgYRUfPyj6o4o7StvNIxMFECeiz4y0uMOVyqc5Y9hjsdFVxdYCeiUjjXLQXA8KIz0iJL3HM0w==}
     engines: {node: '>=20.18.0'}
     hasBin: true
-    bundledDependencies: []
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -4290,6 +4365,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4357,6 +4435,9 @@ packages:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -4367,6 +4448,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
@@ -4521,10 +4605,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
@@ -4532,9 +4618,27 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
@@ -4667,10 +4771,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4689,6 +4795,11 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
@@ -4788,6 +4899,31 @@ packages:
       postcss:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -4820,6 +4956,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -6745,6 +6886,46 @@ snapshots:
       vite: 5.4.19(@types/node@24.0.13)(lightningcss@1.30.1)
       vue: 3.5.18(typescript@5.8.3)
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@24.0.13)(lightningcss@1.30.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@24.0.13)(lightningcss@1.30.1)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.17
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@vue/compiler-core@3.5.18':
     dependencies:
       '@babel/parser': 7.28.0
@@ -6974,6 +7155,8 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  assertion-error@2.0.1: {}
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -7102,6 +7285,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cacache@15.3.0:
     dependencies:
       '@npmcli/fs': 1.1.1
@@ -7140,6 +7325,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -7148,6 +7341,8 @@ snapshots:
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -7420,6 +7615,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   deepmerge-ts@7.1.5: {}
@@ -7563,6 +7760,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -7673,6 +7872,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -7682,6 +7885,8 @@ snapshots:
   events@3.3.0: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.0.1(express@5.1.0):
     dependencies:
@@ -8355,6 +8560,8 @@ snapshots:
       option: 0.2.4
       underscore: 1.13.7
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@6.0.0:
@@ -8738,6 +8945,10 @@ snapshots:
       minipass: 7.1.2
 
   path-to-regexp@8.2.0: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   pdf2json@3.1.6: {}
 
@@ -9198,6 +9409,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7:
     optional: true
 
@@ -9273,11 +9486,15 @@ snapshots:
       minipass: 3.3.6
     optional: true
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stream-browserify@3.0.0:
     dependencies:
@@ -9491,10 +9708,20 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -9655,6 +9882,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@24.0.13)(lightningcss@1.30.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.19(@types/node@24.0.13)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.19(@types/node@24.0.13)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.21.5
@@ -9745,6 +9990,41 @@ snapshots:
       - typescript
       - universal-cookie
 
+  vitest@2.1.9(@types/node@24.0.13)(lightningcss@1.30.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@24.0.13)(lightningcss@1.30.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.4.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.19(@types/node@24.0.13)(lightningcss@1.30.1)
+      vite-node: 2.1.9(@types/node@24.0.13)(lightningcss@1.30.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.0.13
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vue-demi@0.14.10(vue@3.5.18(typescript@5.8.3)):
     dependencies:
       vue: 3.5.18(typescript@5.8.3)
@@ -9771,6 +10051,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:


### PR DESCRIPTION
Depends on https://github.com/LogicLabs-OU/OpenArchiver/pull/423 (for added tests, per CLA)

### Motivation
IMAP ingestion was a throughput bottleneck. For each mailbox the connector fetched envelopes in a batch but then downloaded **each message body with an individual `fetchOne`** (one FETCH round-trip per message), ran **one dedup DB query per envelope**, and **processed emails strictly one-at-a-time** (each `processEmail` awaited before the next). On top of that, sync progress (`maxUid`) was only persisted at *mailbox completion*, so a large mailbox interrupted mid-scan (throttle, hang, restart) threw away all progress and re-scanned from UID 1 — under a daily bandwidth cap, a huge mailbox could loop forever without ever checkpointing.

### What's in here
**Performance**
- **Batched body fetch** — replace per-message `fetchOne` with a single ranged FETCH over the non-duplicate UID set (server-pipelined), streamed + yielded so heap stays bounded to one message. Mid-stream disconnect reconnects and re-fetches only the un-yielded UIDs (retains the old per-message retry robustness).
- **Batched dedup** — new `IngestionService.filterExistingMessageIds()` turns N per-envelope existence queries into **one query per ~250-UID batch**, threaded through `fetchEmails` via an optional `checkDuplicatesBatch` callback (falls back to per-message for other connectors).
- **Bounded-concurrency processing** — yielded emails are dispatched to a small counting-semaphore pool (`INGESTION_EMAIL_CONCURRENCY`, default 8) so DB + object-storage latency overlaps instead of running serially. The IMAP generator is still pulled sequentially; only downstream processing is parallelized. Zero-dep `Semaphore` helper added.
- **Hoisted per-email group lookup** — `findGroupSourceIds` is resolved once per mailbox instead of per message (saves a DB query + credential decrypt + children query on every email).

**Resumable sync**
- **Mid-mailbox checkpointing** — persist `maxUid` on the existing ~5-min heartbeat (draining the in-flight pool first so the checkpoint only covers durably-archived messages, and advancing at *batch* end so we never checkpoint a UID whose body isn't fetched yet). Interrupted syncs now make steady forward progress across throttle windows.
- **Force-sync = full re-scan** — user-initiated "Force sync" clears `sync_state` (source + cascaded children) so it deliberately re-imports from the beginning rather than resuming.

**Config** — every ingestion/indexing concurrency & batch knob is centralized in `config/ingestion.ts` and overridable via env, with defaults identical to prior behavior:

| Env var                               | Default | Purpose                                 |
| ------------------------------------- | ------- | --------------------------------------- |
| `INGESTION_EMAIL_CONCURRENCY`         | 8       | per-mailbox processing concurrency      |
| `INGESTION_WORKER_CONCURRENCY`        | 5       | mailbox jobs in flight                  |
| `IMAP_FETCH_BATCH_SIZE`               | 250     | UID window per FETCH batch              |
| `INDEXING_WORKER_CONCURRENCY`         | 1       | index-batch jobs in flight              |
| `INDEXING_DOCUMENT_BUILD_CONCURRENCY` | 10      | doc builds per index batch              |
| `REINDEX_RESET_BATCH_SIZE`            | 5000    | keyset page size for reindex flag reset |

`intFromEnv()` falls back to the default on non-numeric/≤0 values so a bad override can't zero a pool.

### Behavior change / trade-off
With concurrency > 1, two *distinct* new emails sharing a `Message-ID` within the same window could both pass the dedup gates (`message_id_header` is indexed, not unique). Rare (Pass 1 already filters already-archived dupes), and `INGESTION_EMAIL_CONCURRENCY=1` restores strictly-serial behavior. Defaults preserve existing behavior everywhere else.

### Testing
Adds unit tests for the batching path (injected fake `ImapFlow`: bodies pulled in one ranged FETCH, dupes skipped before body fetch, sync-state advances), the batch dedup path, and the `Semaphore` helper.
