### PR TITLE
Preserve encrypted/signed emails byte-exact and track crypto status

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"build:oss": "pnpm --filter \"./packages/*\" --filter \"!./packages/enterprise\" --filter \"./apps/open-archiver\" build",
 		"build:enterprise": "cross-env VITE_ENTERPRISE_MODE=true pnpm build",
+		"test": "pnpm --filter backend test",
 		"start:oss": "dotenv -- concurrently \"node apps/open-archiver/dist/index.js\" \"pnpm --filter @open-archiver/frontend start\"",
 		"start:enterprise": "dotenv -- concurrently \"node apps/open-archiver-enterprise/dist/index.js\" \"pnpm --filter @open-archiver/frontend start\"",
 		"dev:enterprise": "cross-env VITE_ENTERPRISE_MODE=true dotenv -- pnpm --filter \"@open-archiver/*\" --filter \"open-archiver-enterprise-app\" --parallel dev & pnpm run start:workers:dev",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,6 +13,7 @@
 		"build": "tsc && pnpm copy-assets",
 		"dev": "tsc --watch",
 		"copy-assets": "cp -r src/locales dist/locales",
+		"test": "pnpm build && node test/crypto-mail-p0.test.mjs",
 		"start:ingestion-worker": "node dist/workers/ingestion.worker.js",
 		"start:indexing-worker": "node dist/workers/indexing.worker.js",
 		"start:sync-scheduler": "node dist/jobs/schedulers/sync-scheduler.js",

--- a/packages/backend/src/database/migrations/0041_spotty_jimmy_woo.sql
+++ b/packages/backend/src/database/migrations/0041_spotty_jimmy_woo.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."email_encryption_status" AS ENUM('none', 'encrypted', 'decrypted', 'decrypt_failed');--> statement-breakpoint
+CREATE TYPE "public"."email_signature_status" AS ENUM('none', 'signed_unverified', 'signed_valid', 'signed_invalid', 'signed_unverifiable');--> statement-breakpoint
+ALTER TABLE "archived_emails" ADD COLUMN "encryption_status" "email_encryption_status" DEFAULT 'none' NOT NULL;--> statement-breakpoint
+ALTER TABLE "archived_emails" ADD COLUMN "signature_status" "email_signature_status" DEFAULT 'none' NOT NULL;--> statement-breakpoint
+CREATE INDEX "archived_emails_undecrypted_idx" ON "archived_emails" USING btree ("id") WHERE "archived_emails"."encryption_status" IN ('encrypted', 'decrypt_failed');

--- a/packages/backend/src/database/migrations/meta/0041_snapshot.json
+++ b/packages/backend/src/database/migrations/meta/0041_snapshot.json
@@ -1,0 +1,1927 @@
+{
+	"id": "2997927b-218a-4a0c-892b-2b366785ed77",
+	"prevId": "d4ae1a12-c7a9-4b1a-8801-c19311442b24",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.archived_emails": {
+			"name": "archived_emails",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ingestion_source_id": {
+					"name": "ingestion_source_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"message_id_header": {
+					"name": "message_id_header",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_message_id": {
+					"name": "provider_message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sender_name": {
+					"name": "sender_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sender_email": {
+					"name": "sender_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"recipients": {
+					"name": "recipients",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"storage_path": {
+					"name": "storage_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"storage_hash_sha256": {
+					"name": "storage_hash_sha256",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"size_bytes": {
+					"name": "size_bytes",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"encryption_status": {
+					"name": "encryption_status",
+					"type": "email_encryption_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'none'"
+				},
+				"signature_status": {
+					"name": "signature_status",
+					"type": "email_signature_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'none'"
+				},
+				"is_indexed": {
+					"name": "is_indexed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"index_attempts": {
+					"name": "index_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"has_attachments": {
+					"name": "has_attachments",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_on_legal_hold": {
+					"name": "is_on_legal_hold",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_journaled": {
+					"name": "is_journaled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"thread_id_idx": {
+					"name": "thread_id_idx",
+					"columns": [
+						{
+							"expression": "thread_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_msg_source_idx": {
+					"name": "provider_msg_source_idx",
+					"columns": [
+						{
+							"expression": "provider_message_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ingestion_source_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"msgid_header_source_idx": {
+					"name": "msgid_header_source_idx",
+					"columns": [
+						{
+							"expression": "message_id_header",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ingestion_source_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"storage_hash_source_idx": {
+					"name": "storage_hash_source_idx",
+					"columns": [
+						{
+							"expression": "storage_hash_sha256",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ingestion_source_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"archived_emails_unindexed_idx": {
+					"name": "archived_emails_unindexed_idx",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"archived_emails\".\"is_indexed\" = false",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"archived_emails_undecrypted_idx": {
+					"name": "archived_emails_undecrypted_idx",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"archived_emails\".\"encryption_status\" IN ('encrypted', 'decrypt_failed')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"archived_emails_ingestion_source_id_ingestion_sources_id_fk": {
+					"name": "archived_emails_ingestion_source_id_ingestion_sources_id_fk",
+					"tableFrom": "archived_emails",
+					"tableTo": "ingestion_sources",
+					"columnsFrom": ["ingestion_source_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.attachments": {
+			"name": "attachments",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"filename": {
+					"name": "filename",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"mime_type": {
+					"name": "mime_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size_bytes": {
+					"name": "size_bytes",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_hash_sha256": {
+					"name": "content_hash_sha256",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"storage_path": {
+					"name": "storage_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ingestion_source_id": {
+					"name": "ingestion_source_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"source_hash_idx": {
+					"name": "source_hash_idx",
+					"columns": [
+						{
+							"expression": "ingestion_source_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "content_hash_sha256",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"attachments_ingestion_source_id_ingestion_sources_id_fk": {
+					"name": "attachments_ingestion_source_id_ingestion_sources_id_fk",
+					"tableFrom": "attachments",
+					"tableTo": "ingestion_sources",
+					"columnsFrom": ["ingestion_source_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_attachments": {
+			"name": "email_attachments",
+			"schema": "",
+			"columns": {
+				"email_id": {
+					"name": "email_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attachment_id": {
+					"name": "attachment_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_attachments_email_id_archived_emails_id_fk": {
+					"name": "email_attachments_email_id_archived_emails_id_fk",
+					"tableFrom": "email_attachments",
+					"tableTo": "archived_emails",
+					"columnsFrom": ["email_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"email_attachments_attachment_id_attachments_id_fk": {
+					"name": "email_attachments_attachment_id_attachments_id_fk",
+					"tableFrom": "email_attachments",
+					"tableTo": "attachments",
+					"columnsFrom": ["attachment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"email_attachments_email_id_attachment_id_pk": {
+					"name": "email_attachments_email_id_attachment_id_pk",
+					"columns": ["email_id", "attachment_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.audit_logs": {
+			"name": "audit_logs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigserial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"previous_hash": {
+					"name": "previous_hash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"actor_identifier": {
+					"name": "actor_identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"actor_ip": {
+					"name": "actor_ip",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action_type": {
+					"name": "action_type",
+					"type": "audit_log_action",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_type": {
+					"name": "target_type",
+					"type": "audit_log_target_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"details": {
+					"name": "details",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_hash": {
+					"name": "current_hash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ediscovery_cases": {
+			"name": "ediscovery_cases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'open'"
+				},
+				"created_by_identifier": {
+					"name": "created_by_identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"ediscovery_cases_name_unique": {
+					"name": "ediscovery_cases_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_legal_holds": {
+			"name": "email_legal_holds",
+			"schema": "",
+			"columns": {
+				"email_id": {
+					"name": "email_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"legal_hold_id": {
+					"name": "legal_hold_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"applied_at": {
+					"name": "applied_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"applied_by_user_id": {
+					"name": "applied_by_user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_legal_holds_email_id_archived_emails_id_fk": {
+					"name": "email_legal_holds_email_id_archived_emails_id_fk",
+					"tableFrom": "email_legal_holds",
+					"tableTo": "archived_emails",
+					"columnsFrom": ["email_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"email_legal_holds_legal_hold_id_legal_holds_id_fk": {
+					"name": "email_legal_holds_legal_hold_id_legal_holds_id_fk",
+					"tableFrom": "email_legal_holds",
+					"tableTo": "legal_holds",
+					"columnsFrom": ["legal_hold_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"email_legal_holds_applied_by_user_id_users_id_fk": {
+					"name": "email_legal_holds_applied_by_user_id_users_id_fk",
+					"tableFrom": "email_legal_holds",
+					"tableTo": "users",
+					"columnsFrom": ["applied_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"email_legal_holds_email_id_legal_hold_id_pk": {
+					"name": "email_legal_holds_email_id_legal_hold_id_pk",
+					"columns": ["email_id", "legal_hold_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_retention_labels": {
+			"name": "email_retention_labels",
+			"schema": "",
+			"columns": {
+				"email_id": {
+					"name": "email_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label_id": {
+					"name": "label_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"applied_at": {
+					"name": "applied_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"applied_by_user_id": {
+					"name": "applied_by_user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_retention_labels_email_id_archived_emails_id_fk": {
+					"name": "email_retention_labels_email_id_archived_emails_id_fk",
+					"tableFrom": "email_retention_labels",
+					"tableTo": "archived_emails",
+					"columnsFrom": ["email_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"email_retention_labels_label_id_retention_labels_id_fk": {
+					"name": "email_retention_labels_label_id_retention_labels_id_fk",
+					"tableFrom": "email_retention_labels",
+					"tableTo": "retention_labels",
+					"columnsFrom": ["label_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"email_retention_labels_applied_by_user_id_users_id_fk": {
+					"name": "email_retention_labels_applied_by_user_id_users_id_fk",
+					"tableFrom": "email_retention_labels",
+					"tableTo": "users",
+					"columnsFrom": ["applied_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"email_retention_labels_email_id_label_id_pk": {
+					"name": "email_retention_labels_email_id_label_id_pk",
+					"columns": ["email_id", "label_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.export_jobs": {
+			"name": "export_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"case_id": {
+					"name": "case_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"format": {
+					"name": "format",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"query": {
+					"name": "query",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_by_identifier": {
+					"name": "created_by_identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"export_jobs_case_id_ediscovery_cases_id_fk": {
+					"name": "export_jobs_case_id_ediscovery_cases_id_fk",
+					"tableFrom": "export_jobs",
+					"tableTo": "ediscovery_cases",
+					"columnsFrom": ["case_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.legal_holds": {
+			"name": "legal_holds",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"case_id": {
+					"name": "case_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"legal_holds_case_id_ediscovery_cases_id_fk": {
+					"name": "legal_holds_case_id_ediscovery_cases_id_fk",
+					"tableFrom": "legal_holds",
+					"tableTo": "ediscovery_cases",
+					"columnsFrom": ["case_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.retention_events": {
+			"name": "retention_events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"event_name": {
+					"name": "event_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_timestamp": {
+					"name": "event_timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_criteria": {
+					"name": "target_criteria",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.retention_labels": {
+			"name": "retention_labels",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"retention_period_days": {
+					"name": "retention_period_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_disabled": {
+					"name": "is_disabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.retention_policies": {
+			"name": "retention_policies",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"retention_period_days": {
+					"name": "retention_period_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"action_on_expiry": {
+					"name": "action_on_expiry",
+					"type": "retention_action",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_enabled": {
+					"name": "is_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"conditions": {
+					"name": "conditions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ingestion_scope": {
+					"name": "ingestion_scope",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'null'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"retention_policies_name_unique": {
+					"name": "retention_policies_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.custodians": {
+			"name": "custodians",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "ingestion_provider",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"custodians_email_unique": {
+					"name": "custodians_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ingestion_sources": {
+			"name": "ingestion_sources",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "ingestion_provider",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credentials": {
+					"name": "credentials",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "ingestion_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending_auth'"
+				},
+				"last_sync_started_at": {
+					"name": "last_sync_started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_sync_finished_at": {
+					"name": "last_sync_finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_sync_status_message": {
+					"name": "last_sync_status_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_state": {
+					"name": "sync_state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preserve_original_file": {
+					"name": "preserve_original_file",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"merged_into_id": {
+					"name": "merged_into_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_merged_into": {
+					"name": "idx_merged_into",
+					"columns": [
+						{
+							"expression": "merged_into_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ingestion_sources_user_id_users_id_fk": {
+					"name": "ingestion_sources_user_id_users_id_fk",
+					"tableFrom": "ingestion_sources",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ingestion_sources_merged_into_id_ingestion_sources_id_fk": {
+					"name": "ingestion_sources_merged_into_id_ingestion_sources_id_fk",
+					"tableFrom": "ingestion_sources",
+					"tableTo": "ingestion_sources",
+					"columnsFrom": ["merged_into_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.roles": {
+			"name": "roles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"policies": {
+					"name": "policies",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"roles_name_unique": {
+					"name": "roles_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				},
+				"roles_slug_unique": {
+					"name": "roles_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sessions": {
+			"name": "sessions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"sessions_user_id_users_id_fk": {
+					"name": "sessions_user_id_users_id_fk",
+					"tableFrom": "sessions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_roles": {
+			"name": "user_roles",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_roles_user_id_users_id_fk": {
+					"name": "user_roles_user_id_users_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_roles_role_id_roles_id_fk": {
+					"name": "user_roles_role_id_roles_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_roles_user_id_role_id_pk": {
+					"name": "user_roles_user_id_role_id_pk",
+					"columns": ["user_id", "role_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'local'"
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"totp_secret": {
+					"name": "totp_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"totp_enabled": {
+					"name": "totp_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"totp_enrolled_at": {
+					"name": "totp_enrolled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"totp_backup_codes": {
+					"name": "totp_backup_codes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.system_settings": {
+			"name": "system_settings",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_keys": {
+			"name": "api_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"api_keys_user_id_users_id_fk": {
+					"name": "api_keys_user_id_users_id_fk",
+					"tableFrom": "api_keys",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sync_sessions": {
+			"name": "sync_sessions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"ingestion_source_id": {
+					"name": "ingestion_source_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_initial_import": {
+					"name": "is_initial_import",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"total_mailboxes": {
+					"name": "total_mailboxes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"completed_mailboxes": {
+					"name": "completed_mailboxes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"failed_mailboxes": {
+					"name": "failed_mailboxes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"error_messages": {
+					"name": "error_messages",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"sync_sessions_ingestion_source_id_ingestion_sources_id_fk": {
+					"name": "sync_sessions_ingestion_source_id_ingestion_sources_id_fk",
+					"tableFrom": "sync_sessions",
+					"tableTo": "ingestion_sources",
+					"columnsFrom": ["ingestion_source_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.journaling_sources": {
+			"name": "journaling_sources",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"allowed_ips": {
+					"name": "allowed_ips",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_domains": {
+					"name": "organization_domains",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"require_tls": {
+					"name": "require_tls",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"smtp_username": {
+					"name": "smtp_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"smtp_password_hash": {
+					"name": "smtp_password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "journaling_source_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"ingestion_source_id": {
+					"name": "ingestion_source_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"routing_address": {
+					"name": "routing_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_received": {
+					"name": "total_received",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_received_at": {
+					"name": "last_received_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"journaling_sources_ingestion_source_id_ingestion_sources_id_fk": {
+					"name": "journaling_sources_ingestion_source_id_ingestion_sources_id_fk",
+					"tableFrom": "journaling_sources",
+					"tableTo": "ingestion_sources",
+					"columnsFrom": ["ingestion_source_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.email_encryption_status": {
+			"name": "email_encryption_status",
+			"schema": "public",
+			"values": ["none", "encrypted", "decrypted", "decrypt_failed"]
+		},
+		"public.email_signature_status": {
+			"name": "email_signature_status",
+			"schema": "public",
+			"values": [
+				"none",
+				"signed_unverified",
+				"signed_valid",
+				"signed_invalid",
+				"signed_unverifiable"
+			]
+		},
+		"public.retention_action": {
+			"name": "retention_action",
+			"schema": "public",
+			"values": ["delete_permanently", "notify_admin"]
+		},
+		"public.ingestion_provider": {
+			"name": "ingestion_provider",
+			"schema": "public",
+			"values": [
+				"google_workspace",
+				"microsoft_365",
+				"generic_imap",
+				"pst_import",
+				"eml_import",
+				"mbox_import",
+				"smtp_journaling"
+			]
+		},
+		"public.ingestion_status": {
+			"name": "ingestion_status",
+			"schema": "public",
+			"values": [
+				"active",
+				"paused",
+				"error",
+				"pending_auth",
+				"syncing",
+				"importing",
+				"auth_success",
+				"imported",
+				"partially_active"
+			]
+		},
+		"public.audit_log_action": {
+			"name": "audit_log_action",
+			"schema": "public",
+			"values": [
+				"CREATE",
+				"READ",
+				"UPDATE",
+				"DELETE",
+				"LOGIN",
+				"LOGOUT",
+				"SETUP",
+				"IMPORT",
+				"PAUSE",
+				"SYNC",
+				"UPLOAD",
+				"REINDEX",
+				"SEARCH",
+				"DOWNLOAD",
+				"GENERATE",
+				"TOTP_ENROLLED",
+				"TOTP_DISABLED",
+				"MFA_VERIFY_SUCCESS",
+				"MFA_VERIFY_FAIL",
+				"BACKUP_CODE_USED",
+				"BACKUP_CODES_REGENERATED",
+				"SECURITY_POLICY_UPDATED"
+			]
+		},
+		"public.audit_log_target_type": {
+			"name": "audit_log_target_type",
+			"schema": "public",
+			"values": [
+				"ApiKey",
+				"ArchivedEmail",
+				"Dashboard",
+				"IngestionSource",
+				"JournalingSource",
+				"RetentionPolicy",
+				"RetentionLabel",
+				"LegalHold",
+				"Role",
+				"SystemEvent",
+				"SystemSettings",
+				"User",
+				"File",
+				"SecurityPolicy"
+			]
+		},
+		"public.journaling_source_status": {
+			"name": "journaling_source_status",
+			"schema": "public",
+			"values": ["active", "paused"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/backend/src/database/migrations/meta/_journal.json
+++ b/packages/backend/src/database/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1784721992999,
       "tag": "0040_lively_wolf_cub",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1785194951863,
+      "tag": "0041_spotty_jimmy_woo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/database/schema/archived-emails.ts
+++ b/packages/backend/src/database/schema/archived-emails.ts
@@ -9,8 +9,24 @@ import {
 	uuid,
 	bigint,
 	index,
+	pgEnum,
 } from 'drizzle-orm/pg-core';
 import { ingestionSources } from './ingestion-sources';
+
+export const emailEncryptionStatusEnum = pgEnum('email_encryption_status', [
+	'none',
+	'encrypted',
+	'decrypted',
+	'decrypt_failed',
+]);
+
+export const emailSignatureStatusEnum = pgEnum('email_signature_status', [
+	'none',
+	'signed_unverified',
+	'signed_valid',
+	'signed_invalid',
+	'signed_unverifiable',
+]);
 
 export const archivedEmails = pgTable(
 	'archived_emails',
@@ -33,6 +49,8 @@ export const archivedEmails = pgTable(
 		storagePath: text('storage_path').notNull(),
 		storageHashSha256: text('storage_hash_sha256').notNull(),
 		sizeBytes: bigint('size_bytes', { mode: 'number' }).notNull(),
+		encryptionStatus: emailEncryptionStatusEnum('encryption_status').notNull().default('none'),
+		signatureStatus: emailSignatureStatusEnum('signature_status').notNull().default('none'),
 		isIndexed: boolean('is_indexed').notNull().default(false),
 		/** Number of failed indexing attempts. The reconcile job stops retrying an
 		 * email once this reaches MAX_INDEX_ATTEMPTS, preventing poison emails from
@@ -66,6 +84,9 @@ export const archivedEmails = pgTable(
 		index('archived_emails_unindexed_idx')
 			.on(table.id)
 			.where(sql`${table.isIndexed} = false`),
+		index('archived_emails_undecrypted_idx')
+			.on(table.id)
+			.where(sql`${table.encryptionStatus} IN ('encrypted', 'decrypt_failed')`),
 	]
 );
 

--- a/packages/backend/src/helpers/emlUtils.ts
+++ b/packages/backend/src/helpers/emlUtils.ts
@@ -3,6 +3,12 @@ import MailComposer from 'nodemailer/lib/mail-composer';
 import type Mail from 'nodemailer/lib/mailer';
 import { logger } from '../config/logger';
 
+export type CryptoEnvelopeDetection = {
+	isCryptoEnvelope: boolean;
+	encryption: 'none' | 'smime' | 'pgp_mime' | 'pgp_inline';
+	signature: 'none' | 'smime_opaque' | 'smime_detached' | 'pgp_mime' | 'pgp_inline';
+};
+
 /**
  * Set of headers that are either handled natively by nodemailer's MailComposer
  * via dedicated options, or are structural MIME headers that will be regenerated
@@ -24,6 +30,294 @@ const HEADERS_HANDLED_BY_COMPOSER = new Set([
 	'reply-to',
 	'sender',
 ]);
+
+function emptyDetection(): CryptoEnvelopeDetection {
+	return {
+		isCryptoEnvelope: false,
+		encryption: 'none',
+		signature: 'none',
+	};
+}
+
+function findHeaderEnd(raw: Buffer): { headerEnd: number; bodyStart: number } {
+	const crlf = raw.indexOf('\r\n\r\n');
+	const lf = raw.indexOf('\n\n');
+
+	if (crlf !== -1 && (lf === -1 || crlf < lf)) {
+		return { headerEnd: crlf, bodyStart: crlf + 4 };
+	}
+
+	if (lf !== -1) {
+		return { headerEnd: lf, bodyStart: lf + 2 };
+	}
+
+	return { headerEnd: raw.length, bodyStart: raw.length };
+}
+
+function parseHeaderBlock(headerBlock: string): Map<string, string> {
+	const headers = new Map<string, string>();
+	const lines = headerBlock.replace(/\r\n/g, '\n').split('\n');
+	let currentName = '';
+
+	for (const line of lines) {
+		if (/^[\t ]/.test(line) && currentName) {
+			headers.set(currentName, `${headers.get(currentName) || ''} ${line.trim()}`);
+			continue;
+		}
+
+		const separator = line.indexOf(':');
+		if (separator === -1) {
+			currentName = '';
+			continue;
+		}
+
+		currentName = line.slice(0, separator).toLowerCase();
+		headers.set(currentName, line.slice(separator + 1).trim());
+	}
+
+	return headers;
+}
+
+function splitHeaderValue(value: string): string[] {
+	const parts: string[] = [];
+	let part = '';
+	let quoted = false;
+
+	for (let i = 0; i < value.length; i += 1) {
+		const char = value[i];
+		if (char === '"' && value[i - 1] !== '\\') {
+			quoted = !quoted;
+		}
+		if (char === ';' && !quoted) {
+			parts.push(part.trim());
+			part = '';
+			continue;
+		}
+		part += char;
+	}
+	parts.push(part.trim());
+	return parts;
+}
+
+function unquote(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function parseStructuredHeader(value: string | undefined): {
+	value: string;
+	params: Map<string, string>;
+} {
+	if (!value) {
+		return { value: '', params: new Map() };
+	}
+
+	const [mediaType = '', ...paramParts] = splitHeaderValue(value);
+	const params = new Map<string, string>();
+
+	for (const paramPart of paramParts) {
+		const separator = paramPart.indexOf('=');
+		if (separator === -1) {
+			continue;
+		}
+		params.set(
+			paramPart.slice(0, separator).trim().toLowerCase(),
+			unquote(paramPart.slice(separator + 1))
+		);
+	}
+
+	return {
+		value: mediaType.toLowerCase(),
+		params,
+	};
+}
+
+function filenamesFromHeaders(headers: Map<string, string>): string[] {
+	const names: string[] = [];
+	for (const header of ['content-type', 'content-disposition']) {
+		const parsed = parseStructuredHeader(headers.get(header));
+		for (const key of ['name', 'filename']) {
+			const value = parsed.params.get(key);
+			if (value) {
+				names.push(value.toLowerCase());
+			}
+		}
+	}
+	return names;
+}
+
+function getFirstLevelParts(body: string, boundary: string | undefined): Map<string, string>[] {
+	if (!boundary) {
+		return [];
+	}
+
+	const parts: Map<string, string>[] = [];
+	const lines = body.replace(/\r\n/g, '\n').split('\n');
+	const boundaryLine = `--${boundary}`;
+	const closingBoundaryLine = `--${boundary}--`;
+	let partLines: string[] | null = null;
+
+	for (const line of lines) {
+		const trimmed = line.trimEnd();
+		if (trimmed === boundaryLine || trimmed === closingBoundaryLine) {
+			if (partLines) {
+				const partText = partLines.join('\n');
+				const headerEnd = partText.indexOf('\n\n');
+				const headerBlock = headerEnd === -1 ? partText : partText.slice(0, headerEnd);
+				parts.push(parseHeaderBlock(headerBlock));
+			}
+			partLines = trimmed === closingBoundaryLine ? null : [];
+			if (trimmed === closingBoundaryLine) {
+				break;
+			}
+			continue;
+		}
+
+		if (partLines) {
+			partLines.push(line);
+		}
+	}
+
+	return parts;
+}
+
+function bodyContainsPgp(body: string): Pick<CryptoEnvelopeDetection, 'encryption' | 'signature'> {
+	if (
+		body.includes('-----BEGIN PGP MESSAGE-----') &&
+		body.includes('-----END PGP MESSAGE-----')
+	) {
+		return { encryption: 'pgp_inline', signature: 'none' };
+	}
+
+	if (body.includes('-----BEGIN PGP SIGNED MESSAGE-----')) {
+		return { encryption: 'none', signature: 'pgp_inline' };
+	}
+
+	return { encryption: 'none', signature: 'none' };
+}
+
+/**
+ * Detects top-level S/MIME and PGP envelopes without parsing or reserializing MIME.
+ */
+export function detectCryptoEnvelope(raw: Buffer): CryptoEnvelopeDetection {
+	const { headerEnd, bodyStart } = findHeaderEnd(raw);
+	const headers = parseHeaderBlock(raw.subarray(0, headerEnd).toString('latin1'));
+	const contentType = parseStructuredHeader(headers.get('content-type'));
+	const contentDisposition = parseStructuredHeader(headers.get('content-disposition'));
+	const topLevelType = contentType.value;
+	const smimeType = contentType.params.get('smime-type')?.toLowerCase();
+	const protocol = contentType.params.get('protocol')?.toLowerCase();
+	const filenames = [
+		...filenamesFromHeaders(headers),
+		contentType.params.get('name') || '',
+		contentDisposition.params.get('filename') || '',
+	];
+	const hasFilename = (filename: string) => filenames.some((name) => name === filename);
+	const isPkcs7Mime =
+		topLevelType === 'application/pkcs7-mime' || topLevelType === 'application/x-pkcs7-mime';
+	const isPkcs7Signature =
+		topLevelType === 'application/pkcs7-signature' ||
+		topLevelType === 'application/x-pkcs7-signature';
+
+	if (isPkcs7Mime) {
+		if (smimeType === 'certs-only' || hasFilename('smime.p7c')) {
+			return { ...emptyDetection(), isCryptoEnvelope: true };
+		}
+
+		if (smimeType === 'signed-data') {
+			return {
+				isCryptoEnvelope: true,
+				encryption: 'none',
+				signature: 'smime_opaque',
+			};
+		}
+
+		return {
+			isCryptoEnvelope: true,
+			encryption: 'smime',
+			signature: 'none',
+		};
+	}
+
+	if (isPkcs7Signature) {
+		return {
+			isCryptoEnvelope: true,
+			encryption: 'none',
+			signature: 'smime_detached',
+		};
+	}
+
+	const bodyProbe = raw
+		.subarray(bodyStart, Math.min(raw.length, bodyStart + 64 * 1024))
+		.toString('latin1');
+
+	if (topLevelType.startsWith('multipart/')) {
+		const parts = getFirstLevelParts(bodyProbe, contentType.params.get('boundary'));
+		const partTypes = parts.map(
+			(part) => parseStructuredHeader(part.get('content-type')).value
+		);
+		const partFilenames = parts.flatMap(filenamesFromHeaders);
+
+		if (topLevelType === 'multipart/encrypted') {
+			if (
+				protocol === 'application/pgp-encrypted' ||
+				partTypes.includes('application/pgp-encrypted') ||
+				partFilenames.includes('encrypted.asc')
+			) {
+				return {
+					isCryptoEnvelope: true,
+					encryption: 'pgp_mime',
+					signature: 'none',
+				};
+			}
+		}
+
+		if (topLevelType === 'multipart/signed') {
+			if (
+				protocol === 'application/pgp-signature' ||
+				partTypes.includes('application/pgp-signature') ||
+				partFilenames.includes('signature.asc')
+			) {
+				return {
+					isCryptoEnvelope: true,
+					encryption: 'none',
+					signature: 'pgp_mime',
+				};
+			}
+
+			if (
+				protocol === 'application/pkcs7-signature' ||
+				protocol === 'application/x-pkcs7-signature' ||
+				partTypes.includes('application/pkcs7-signature') ||
+				partTypes.includes('application/x-pkcs7-signature') ||
+				partFilenames.includes('smime.p7s')
+			) {
+				return {
+					isCryptoEnvelope: true,
+					encryption: 'none',
+					signature: 'smime_detached',
+				};
+			}
+		}
+
+		const inlinePgp = bodyContainsPgp(bodyProbe);
+		if (inlinePgp.encryption !== 'none' || inlinePgp.signature !== 'none') {
+			return { isCryptoEnvelope: true, ...inlinePgp };
+		}
+	}
+
+	if (topLevelType === 'text/plain') {
+		const inlinePgp = bodyContainsPgp(bodyProbe);
+		if (inlinePgp.encryption !== 'none' || inlinePgp.signature !== 'none') {
+			return { isCryptoEnvelope: true, ...inlinePgp };
+		}
+	}
+
+	return emptyDetection();
+}
 
 /**
  * Determines whether a parsed attachment should be preserved in the stored .eml.
@@ -139,6 +433,10 @@ function addressToString(
  */
 export async function stripAttachmentsFromEml(emlBuffer: Buffer): Promise<Buffer> {
 	try {
+		if (detectCryptoEnvelope(emlBuffer).isCryptoEnvelope) {
+			return emlBuffer;
+		}
+
 		const parsed = await simpleParser(emlBuffer);
 
 		// If there are no attachments at all, return early

--- a/packages/backend/src/helpers/emlUtils.ts
+++ b/packages/backend/src/helpers/emlUtils.ts
@@ -5,8 +5,8 @@ import { logger } from '../config/logger';
 
 export type CryptoEnvelopeDetection = {
 	isCryptoEnvelope: boolean;
-	encryption: 'none' | 'smime' | 'pgp_mime' | 'pgp_inline';
-	signature: 'none' | 'smime_opaque' | 'smime_detached' | 'pgp_mime' | 'pgp_inline';
+	encryption: 'none' | 'smime' | 'pgp_mime' | 'pgp_inline' | 'other';
+	signature: 'none' | 'smime_opaque' | 'smime_detached' | 'pgp_mime' | 'pgp_inline' | 'other';
 };
 
 /**
@@ -273,6 +273,14 @@ export function detectCryptoEnvelope(raw: Buffer): CryptoEnvelopeDetection {
 					signature: 'none',
 				};
 			}
+
+			// RFC 1847: multipart/encrypted is always an encrypted envelope, even
+			// with an unknown or missing protocol — never let it reach stripping.
+			return {
+				isCryptoEnvelope: true,
+				encryption: 'other',
+				signature: 'none',
+			};
 		}
 
 		if (topLevelType === 'multipart/signed') {
@@ -301,6 +309,15 @@ export function detectCryptoEnvelope(raw: Buffer): CryptoEnvelopeDetection {
 					signature: 'smime_detached',
 				};
 			}
+
+			// RFC 1847: multipart/signed always carries a signature over the exact
+			// bytes of the first part; re-serializing destroys it regardless of the
+			// (possibly unknown, missing, or beyond-probe) protocol.
+			return {
+				isCryptoEnvelope: true,
+				encryption: 'none',
+				signature: 'other',
+			};
 		}
 
 		const inlinePgp = bodyContainsPgp(bodyProbe);

--- a/packages/backend/src/helpers/emlUtils.ts
+++ b/packages/backend/src/helpers/emlUtils.ts
@@ -149,12 +149,17 @@ function filenamesFromHeaders(headers: Map<string, string>): string[] {
 	return names;
 }
 
-function getFirstLevelParts(body: string, boundary: string | undefined): Map<string, string>[] {
+type MimePartProbe = {
+	headers: Map<string, string>;
+	body: string;
+};
+
+function getFirstLevelParts(body: string, boundary: string | undefined): MimePartProbe[] {
 	if (!boundary) {
 		return [];
 	}
 
-	const parts: Map<string, string>[] = [];
+	const parts: MimePartProbe[] = [];
 	const lines = body.replace(/\r\n/g, '\n').split('\n');
 	const boundaryLine = `--${boundary}`;
 	const closingBoundaryLine = `--${boundary}--`;
@@ -167,7 +172,8 @@ function getFirstLevelParts(body: string, boundary: string | undefined): Map<str
 				const partText = partLines.join('\n');
 				const headerEnd = partText.indexOf('\n\n');
 				const headerBlock = headerEnd === -1 ? partText : partText.slice(0, headerEnd);
-				parts.push(parseHeaderBlock(headerBlock));
+				const partBody = headerEnd === -1 ? '' : partText.slice(headerEnd + 2);
+				parts.push({ headers: parseHeaderBlock(headerBlock), body: partBody });
 			}
 			partLines = trimmed === closingBoundaryLine ? null : [];
 			if (trimmed === closingBoundaryLine) {
@@ -184,15 +190,20 @@ function getFirstLevelParts(body: string, boundary: string | undefined): Map<str
 	return parts;
 }
 
+const PGP_MESSAGE_BEGIN = /^-----BEGIN PGP MESSAGE-----/m;
+const PGP_MESSAGE_END = /^-----END PGP MESSAGE-----/m;
+const PGP_SIGNED_BEGIN = /^-----BEGIN PGP SIGNED MESSAGE-----/m;
+
 function bodyContainsPgp(body: string): Pick<CryptoEnvelopeDetection, 'encryption' | 'signature'> {
-	if (
-		body.includes('-----BEGIN PGP MESSAGE-----') &&
-		body.includes('-----END PGP MESSAGE-----')
-	) {
+	// Anchored at line start so quoted armor in replies ("> -----BEGIN ...")
+	// does not flag an ordinary email as encrypted.
+	const normalized = body.replace(/\r\n/g, '\n');
+
+	if (PGP_MESSAGE_BEGIN.test(normalized) && PGP_MESSAGE_END.test(normalized)) {
 		return { encryption: 'pgp_inline', signature: 'none' };
 	}
 
-	if (body.includes('-----BEGIN PGP SIGNED MESSAGE-----')) {
+	if (PGP_SIGNED_BEGIN.test(normalized)) {
 		return { encryption: 'none', signature: 'pgp_inline' };
 	}
 
@@ -257,9 +268,9 @@ export function detectCryptoEnvelope(raw: Buffer): CryptoEnvelopeDetection {
 	if (topLevelType.startsWith('multipart/')) {
 		const parts = getFirstLevelParts(bodyProbe, contentType.params.get('boundary'));
 		const partTypes = parts.map(
-			(part) => parseStructuredHeader(part.get('content-type')).value
+			(part) => parseStructuredHeader(part.headers.get('content-type')).value
 		);
-		const partFilenames = parts.flatMap(filenamesFromHeaders);
+		const partFilenames = parts.flatMap((part) => filenamesFromHeaders(part.headers));
 
 		if (topLevelType === 'multipart/encrypted') {
 			if (
@@ -320,9 +331,18 @@ export function detectCryptoEnvelope(raw: Buffer): CryptoEnvelopeDetection {
 			};
 		}
 
-		const inlinePgp = bodyContainsPgp(bodyProbe);
-		if (inlinePgp.encryption !== 'none' || inlinePgp.signature !== 'none') {
-			return { isCryptoEnvelope: true, ...inlinePgp };
+		// Only inline PGP in the message text itself makes this a crypto
+		// envelope; armor inside attachments (.asc files, quoted forwards)
+		// must not stop attachment stripping.
+		const firstTextPart = parts.find((part, index) => {
+			const partType = partTypes[index];
+			return partType === 'text/plain' || partType === '';
+		});
+		if (firstTextPart) {
+			const inlinePgp = bodyContainsPgp(firstTextPart.body);
+			if (inlinePgp.encryption !== 'none' || inlinePgp.signature !== 'none') {
+				return { isCryptoEnvelope: true, ...inlinePgp };
+			}
 		}
 	}
 

--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -21,7 +21,7 @@ import type {
 	ReindexMode,
 	IngestionStats,
 } from '@open-archiver/types';
-import { stripAttachmentsFromEml } from '../helpers/emlUtils';
+import { detectCryptoEnvelope, stripAttachmentsFromEml } from '../helpers/emlUtils';
 import {
 	archivedEmails,
 	attachments as attachmentsSchema,
@@ -41,6 +41,16 @@ import { checkDeletionEnabled } from '../helpers/deletionGuard';
  * so inserting null (from a missing/unparseable sender, e.g. Exchange "Deleted Items"
  * system messages) would fail with Postgres 23502 and drop the email entirely. */
 const UNKNOWN_SENDER = 'unknown@no-sender.invalid';
+
+function cryptoStatusesFromDetection(detection: ReturnType<typeof detectCryptoEnvelope>): {
+	encryptionStatus: 'none' | 'encrypted';
+	signatureStatus: 'none' | 'signed_unverified';
+} {
+	return {
+		encryptionStatus: detection.encryption === 'none' ? 'none' : 'encrypted',
+		signatureStatus: detection.signature === 'none' ? 'none' : 'signed_unverified',
+	};
+}
 
 export class IngestionService {
 	private static auditService = new AuditService();
@@ -903,6 +913,8 @@ export class IngestionService {
 		try {
 			// Read the raw bytes from the temp file written by the connector
 			const rawEmlBuffer = await readFile(email.tempFilePath);
+			const cryptoDetection = detectCryptoEnvelope(rawEmlBuffer);
+			const cryptoStatuses = cryptoStatusesFromDetection(cryptoDetection);
 
 			// If this source is a child in a merge group, redirect all storage and DB
 			// ownership to the root source. Child sources are "assistants" — they fetch
@@ -972,6 +984,8 @@ export class IngestionService {
 					storageHashSha256: true,
 					sizeBytes: true,
 					hasAttachments: true,
+					encryptionStatus: true,
+					signatureStatus: true,
 				},
 			});
 
@@ -1000,6 +1014,8 @@ export class IngestionService {
 						storageHashSha256: existingGroupEmail.storageHashSha256,
 						sizeBytes: existingGroupEmail.sizeBytes,
 						hasAttachments: existingGroupEmail.hasAttachments,
+						encryptionStatus: existingGroupEmail.encryptionStatus,
+						signatureStatus: existingGroupEmail.signatureStatus,
 						isJournaled: effectiveSource.provider === 'smtp_journaling',
 						path: email.path,
 						tags: email.tags,
@@ -1120,6 +1136,7 @@ export class IngestionService {
 						storageHashSha256: emailHash,
 						sizeBytes: rawEmlBuffer.length,
 						hasAttachments: email.attachments.length > 0,
+						...cryptoStatuses,
 						isJournaled: effectiveSource.provider === 'smtp_journaling',
 						path: email.path,
 						tags: email.tags,
@@ -1133,7 +1150,9 @@ export class IngestionService {
 
 			// Default mode: strip non-inline attachments from the .eml to avoid double-storing
 			// attachment data (attachments are stored separately).
-			const emlBuffer = await stripAttachmentsFromEml(rawEmlBuffer);
+			const emlBuffer = cryptoDetection.isCryptoEnvelope
+				? rawEmlBuffer
+				: await stripAttachmentsFromEml(rawEmlBuffer);
 			const emailHash = createHash('sha256').update(emlBuffer).digest('hex');
 			await storage.put(emailPath, emlBuffer);
 
@@ -1158,6 +1177,7 @@ export class IngestionService {
 					storageHashSha256: emailHash,
 					sizeBytes: emlBuffer.length,
 					hasAttachments: email.attachments.length > 0,
+					...cryptoStatuses,
 					isJournaled: effectiveSource.provider === 'smtp_journaling',
 					path: email.path,
 					tags: email.tags,

--- a/packages/backend/test/crypto-mail-p0.test.mjs
+++ b/packages/backend/test/crypto-mail-p0.test.mjs
@@ -67,6 +67,11 @@ const matrixCases = [
 		'multipart-signed-unknown-protocol.eml',
 		{ isCryptoEnvelope: true, encryption: 'none', signature: 'other' },
 	],
+	['quoted-pgp-reply.eml', { isCryptoEnvelope: false, encryption: 'none', signature: 'none' }],
+	[
+		'pgp-attachment-normal.eml',
+		{ isCryptoEnvelope: false, encryption: 'none', signature: 'none' },
+	],
 	[
 		'normal-with-attachment.eml',
 		{ isCryptoEnvelope: false, encryption: 'none', signature: 'none' },
@@ -98,5 +103,20 @@ assert.notEqual(Buffer.compare(normalStripped, normalRaw), 0, 'normal email shou
 const parsedNormal = await simpleParser(normalStripped);
 assert.equal(parsedNormal.text?.includes('Plain body that should survive stripping.'), true);
 assert.equal(parsedNormal.attachments.length, 0);
+
+const pgpAttachmentRaw = fixture('pgp-attachment-normal.eml');
+const pgpAttachmentStripped = await stripAttachmentsFromEml(pgpAttachmentRaw);
+assert.notEqual(
+	Buffer.compare(pgpAttachmentStripped, pgpAttachmentRaw),
+	0,
+	'pgp .asc attachment email should be rebuilt'
+);
+
+const parsedPgpAttachment = await simpleParser(pgpAttachmentStripped);
+assert.equal(
+	parsedPgpAttachment.text?.includes('Plain body; the armor below lives in an attachment only.'),
+	true
+);
+assert.equal(parsedPgpAttachment.attachments.length, 0);
 
 console.log('crypto-mail P0 tests passed');

--- a/packages/backend/test/crypto-mail-p0.test.mjs
+++ b/packages/backend/test/crypto-mail-p0.test.mjs
@@ -60,6 +60,14 @@ const matrixCases = [
 	],
 	['smime-certs-only.eml', { isCryptoEnvelope: true, encryption: 'none', signature: 'none' }],
 	[
+		'multipart-encrypted-unknown-protocol.eml',
+		{ isCryptoEnvelope: true, encryption: 'other', signature: 'none' },
+	],
+	[
+		'multipart-signed-unknown-protocol.eml',
+		{ isCryptoEnvelope: true, encryption: 'none', signature: 'other' },
+	],
+	[
 		'normal-with-attachment.eml',
 		{ isCryptoEnvelope: false, encryption: 'none', signature: 'none' },
 	],
@@ -75,6 +83,8 @@ for (const name of [
 	'smime-detached-signed.eml',
 	'pgp-mime-encrypted.eml',
 	'pgp-mime-signed.eml',
+	'multipart-encrypted-unknown-protocol.eml',
+	'multipart-signed-unknown-protocol.eml',
 ]) {
 	const raw = fixture(name);
 	const stripped = await stripAttachmentsFromEml(raw);

--- a/packages/backend/test/crypto-mail-p0.test.mjs
+++ b/packages/backend/test/crypto-mail-p0.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { simpleParser } from 'mailparser';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(here, 'fixtures', 'crypto-mail');
+const distHelperPath = join(here, '..', 'dist', 'helpers', 'emlUtils.js');
+
+if (!existsSync(join(fixturesDir, 'smime-enveloped.eml'))) {
+	execFileSync('bash', [join(fixturesDir, 'gen-fixtures.sh')], { stdio: 'inherit' });
+}
+
+if (!existsSync(distHelperPath)) {
+	throw new Error('Build backend before running this test: pnpm --filter backend build');
+}
+
+const { detectCryptoEnvelope, stripAttachmentsFromEml } = await import(distHelperPath);
+
+function fixture(name) {
+	return readFileSync(join(fixturesDir, name));
+}
+
+const matrixCases = [
+	['smime-enveloped.eml', { isCryptoEnvelope: true, encryption: 'smime', signature: 'none' }],
+	[
+		'smime-enveloped-pkcs7.eml',
+		{ isCryptoEnvelope: true, encryption: 'smime', signature: 'none' },
+	],
+	[
+		'smime-opaque-signed.eml',
+		{ isCryptoEnvelope: true, encryption: 'none', signature: 'smime_opaque' },
+	],
+	[
+		'smime-detached-signed.eml',
+		{ isCryptoEnvelope: true, encryption: 'none', signature: 'smime_detached' },
+	],
+	[
+		'pgp-mime-encrypted.eml',
+		{ isCryptoEnvelope: true, encryption: 'pgp_mime', signature: 'none' },
+	],
+	['pgp-mime-signed.eml', { isCryptoEnvelope: true, encryption: 'none', signature: 'pgp_mime' }],
+	[
+		'pgp-inline-encrypted.eml',
+		{ isCryptoEnvelope: true, encryption: 'pgp_inline', signature: 'none' },
+	],
+	[
+		'pgp-inline-signed.eml',
+		{ isCryptoEnvelope: true, encryption: 'none', signature: 'pgp_inline' },
+	],
+	[
+		'smime-filename-fallback-p7m.eml',
+		{ isCryptoEnvelope: true, encryption: 'smime', signature: 'none' },
+	],
+	[
+		'smime-filename-fallback-p7s.eml',
+		{ isCryptoEnvelope: true, encryption: 'none', signature: 'smime_detached' },
+	],
+	['smime-certs-only.eml', { isCryptoEnvelope: true, encryption: 'none', signature: 'none' }],
+	[
+		'normal-with-attachment.eml',
+		{ isCryptoEnvelope: false, encryption: 'none', signature: 'none' },
+	],
+];
+
+for (const [name, expected] of matrixCases) {
+	assert.deepEqual(detectCryptoEnvelope(fixture(name)), expected, name);
+}
+
+for (const name of [
+	'smime-enveloped.eml',
+	'smime-opaque-signed.eml',
+	'smime-detached-signed.eml',
+	'pgp-mime-encrypted.eml',
+	'pgp-mime-signed.eml',
+]) {
+	const raw = fixture(name);
+	const stripped = await stripAttachmentsFromEml(raw);
+	assert.equal(Buffer.compare(stripped, raw), 0, `${name} must pass through byte-identical`);
+}
+
+const normalRaw = fixture('normal-with-attachment.eml');
+const normalStripped = await stripAttachmentsFromEml(normalRaw);
+assert.notEqual(Buffer.compare(normalStripped, normalRaw), 0, 'normal email should be rebuilt');
+
+const parsedNormal = await simpleParser(normalStripped);
+assert.equal(parsedNormal.text?.includes('Plain body that should survive stripping.'), true);
+assert.equal(parsedNormal.attachments.length, 0);
+
+console.log('crypto-mail P0 tests passed');

--- a/packages/backend/test/fixtures/crypto-mail/.gitignore
+++ b/packages/backend/test/fixtures/crypto-mail/.gitignore
@@ -1,0 +1,4 @@
+*.eml
+smime.key
+smime.crt
+tmp/

--- a/packages/backend/test/fixtures/crypto-mail/gen-fixtures.sh
+++ b/packages/backend/test/fixtures/crypto-mail/gen-fixtures.sh
@@ -97,6 +97,44 @@ Content-Transfer-Encoding: base64
 MIIBFAKECERTS
 EML
 
+cat >multipart-encrypted-unknown-protocol.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: multipart/encrypted with unknown protocol
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; protocol="application/vnd.example-encryption"; boundary="unknown-encrypted-boundary"
+
+--unknown-encrypted-boundary
+Content-Type: application/vnd.example-encryption
+
+Version: 1
+
+--unknown-encrypted-boundary
+Content-Type: application/octet-stream
+
+BASE64CIPHERTEXTPAYLOAD
+--unknown-encrypted-boundary--
+EML
+
+cat >multipart-signed-unknown-protocol.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: multipart/signed with unknown protocol
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/vnd.example-signature"; boundary="unknown-signed-boundary"
+
+--unknown-signed-boundary
+Content-Type: text/plain; charset=utf-8
+
+Signed content with an unrecognized signature protocol.
+
+--unknown-signed-boundary
+Content-Type: application/vnd.example-signature
+
+FAKESIGNATUREBLOB
+--unknown-signed-boundary--
+EML
+
 cat >pgp-mime-encrypted.eml <<'EML'
 From: alice@example.test
 To: bob@example.test

--- a/packages/backend/test/fixtures/crypto-mail/gen-fixtures.sh
+++ b/packages/backend/test/fixtures/crypto-mail/gen-fixtures.sh
@@ -52,7 +52,7 @@ openssl smime -encrypt \
 	smime.crt
 
 cat >smime-enveloped-pkcs7.eml <smime-enveloped.eml
-perl -0pi -e 's/application\/x-pkcs7-mime/application\/pkcs7-mime/gi' smime-enveloped-pkcs7.eml
+sed -i 's|application/x-pkcs7-mime|application/pkcs7-mime|gI' smime-enveloped-pkcs7.eml
 
 cat >smime-filename-fallback-p7m.eml <<'EML'
 From: alice@example.test
@@ -217,6 +217,48 @@ Clear signed body.
 owEBFAKEPGPSIGNATURE
 =test
 -----END PGP SIGNATURE-----
+EML
+
+cat >quoted-pgp-reply.eml <<'EML'
+From: bob@example.test
+To: alice@example.test
+Subject: Re: your encrypted note
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Thanks, I got it. For reference you sent:
+
+> -----BEGIN PGP MESSAGE-----
+>
+> owEBFAKEQUOTEDPGP
+> =test
+> -----END PGP MESSAGE-----
+
+Talk soon.
+EML
+
+cat >pgp-attachment-normal.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: Plain mail with PGP file attached
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="pgp-attachment-boundary"
+
+--pgp-attachment-boundary
+Content-Type: text/plain; charset=utf-8
+
+Plain body; the armor below lives in an attachment only.
+
+--pgp-attachment-boundary
+Content-Type: application/octet-stream; name="secret-note.asc"
+Content-Disposition: attachment; filename="secret-note.asc"
+
+-----BEGIN PGP MESSAGE-----
+
+owEBFAKEATTACHEDPGP
+=test
+-----END PGP MESSAGE-----
+--pgp-attachment-boundary--
 EML
 
 cat >normal-with-attachment.eml <<'EML'

--- a/packages/backend/test/fixtures/crypto-mail/gen-fixtures.sh
+++ b/packages/backend/test/fixtures/crypto-mail/gen-fixtures.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+rm -rf tmp
+mkdir -p tmp
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+	-keyout smime.key \
+	-out smime.crt \
+	-subj "/CN=OpenArchiver Crypto Mail Test/" \
+	-days 1 >/dev/null 2>&1
+
+cat >tmp/signed-content.mime <<'MIME'
+Content-Type: text/plain; charset=utf-8
+MIME-Version: 1.0
+
+Signed body text that must keep its MIME signature envelope.
+MIME
+
+openssl smime -sign \
+	-in tmp/signed-content.mime \
+	-out smime-detached-signed.eml \
+	-signer smime.crt \
+	-inkey smime.key \
+	-from alice@example.test \
+	-to bob@example.test \
+	-subject "S/MIME detached signed fixture" \
+	-outform SMIME
+
+openssl smime -sign -nodetach \
+	-in tmp/signed-content.mime \
+	-out smime-opaque-signed.eml \
+	-signer smime.crt \
+	-inkey smime.key \
+	-from alice@example.test \
+	-to bob@example.test \
+	-subject "S/MIME opaque signed fixture" \
+	-outform SMIME
+
+cat >tmp/encrypted-body.txt <<'EOF'
+Encrypted body text that must not disappear from the archived EML.
+EOF
+
+openssl smime -encrypt \
+	-in tmp/encrypted-body.txt \
+	-out smime-enveloped.eml \
+	-from alice@example.test \
+	-to bob@example.test \
+	-subject "S/MIME enveloped fixture" \
+	-outform SMIME \
+	smime.crt
+
+cat >smime-enveloped-pkcs7.eml <smime-enveloped.eml
+perl -0pi -e 's/application\/x-pkcs7-mime/application\/pkcs7-mime/gi' smime-enveloped-pkcs7.eml
+
+cat >smime-filename-fallback-p7m.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: S/MIME filename fallback
+MIME-Version: 1.0
+Content-Type: application/pkcs7-mime; name="smime.p7m"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7m"
+
+MIIBFAKECMSPAYLOAD
+EML
+
+cat >smime-filename-fallback-p7s.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: S/MIME signature filename fallback
+MIME-Version: 1.0
+Content-Type: multipart/signed; boundary="fallback-p7s-boundary"
+
+--fallback-p7s-boundary
+Content-Type: text/plain; charset=utf-8
+
+Signed content.
+
+--fallback-p7s-boundary
+Content-Type: application/octet-stream; name="smime.p7s"
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIBFAKESIGNATURE
+--fallback-p7s-boundary--
+EML
+
+cat >smime-certs-only.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: S/MIME certs only
+MIME-Version: 1.0
+Content-Type: application/pkcs7-mime; smime-type=certs-only; name="smime.p7c"
+Content-Transfer-Encoding: base64
+
+MIIBFAKECERTS
+EML
+
+cat >pgp-mime-encrypted.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: PGP/MIME encrypted fixture
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted"; boundary="pgp-encrypted-boundary"
+
+--pgp-encrypted-boundary
+Content-Type: application/pgp-encrypted
+
+Version: 1
+
+--pgp-encrypted-boundary
+Content-Type: application/octet-stream; name="encrypted.asc"
+Content-Disposition: inline; filename="encrypted.asc"
+
+-----BEGIN PGP MESSAGE-----
+
+Version: OpenArchiver Test
+
+owEBFAKEPGPMESSAGE
+=test
+-----END PGP MESSAGE-----
+--pgp-encrypted-boundary--
+EML
+
+cat >pgp-mime-signed.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: PGP/MIME signed fixture
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pgp-signature"; micalg=pgp-sha256; boundary="pgp-signed-boundary"
+
+--pgp-signed-boundary
+Content-Type: text/plain; charset=utf-8
+
+PGP signed body.
+
+--pgp-signed-boundary
+Content-Type: application/pgp-signature; name="signature.asc"
+Content-Disposition: attachment; filename="signature.asc"
+
+-----BEGIN PGP SIGNATURE-----
+
+owEBFAKEPGPSIGNATURE
+=test
+-----END PGP SIGNATURE-----
+--pgp-signed-boundary--
+EML
+
+cat >pgp-inline-encrypted.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: Inline PGP encrypted fixture
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+-----BEGIN PGP MESSAGE-----
+
+Version: OpenArchiver Test
+
+owEBFAKEINLINEPGP
+=test
+-----END PGP MESSAGE-----
+EML
+
+cat >pgp-inline-signed.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: Inline PGP signed fixture
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+Clear signed body.
+-----BEGIN PGP SIGNATURE-----
+
+owEBFAKEPGPSIGNATURE
+=test
+-----END PGP SIGNATURE-----
+EML
+
+cat >normal-with-attachment.eml <<'EML'
+From: alice@example.test
+To: bob@example.test
+Subject: Normal attachment fixture
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="normal-attachment-boundary"
+
+--normal-attachment-boundary
+Content-Type: text/plain; charset=utf-8
+
+Plain body that should survive stripping.
+
+--normal-attachment-boundary
+Content-Type: text/plain; name="ordinary.txt"
+Content-Disposition: attachment; filename="ordinary.txt"
+Content-Transfer-Encoding: base64
+
+T3JkaW5hcnkgYXR0YWNobWVudCB0aGF0IHNob3VsZCBiZSBzdHJpcHBlZC4=
+--normal-attachment-boundary--
+EML
+
+rm -rf tmp

--- a/packages/frontend/src/lib/translations/en.json
+++ b/packages/frontend/src/lib/translations/en.json
@@ -69,6 +69,8 @@
 			"retention_policy_overridden_by_label": "This policy is overridden by retention label ",
 			"embedded_attachments": "Embedded Attachments",
 			"embedded": "Embedded",
+			"encrypted": "Encrypted",
+			"signed": "Signed",
 			"embedded_attachment_title": "Embedded Attachment",
 			"embedded_attachment_description": "This attachment is embedded in the original email file and cannot be downloaded separately. To get this attachment, download the complete email (.eml) file."
 		},

--- a/packages/frontend/src/routes/dashboard/archived-emails/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/archived-emails/+page.svelte
@@ -10,9 +10,12 @@
 	import * as Pagination from '$lib/components/ui/pagination/index.js';
 	import ChevronLeft from 'lucide-svelte/icons/chevron-left';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import LockKeyhole from 'lucide-svelte/icons/lock-keyhole';
+	import BadgeCheck from 'lucide-svelte/icons/badge-check';
 	import { api } from '$lib/api.client';
 	import { setAlert } from '$lib/components/custom/alert/alert-state.svelte';
 	import type { PaginatedArchivedEmails } from '@open-archiver/types';
+	import { Badge } from '$lib/components/ui/badge';
 
 	let { data }: { data: PageData } = $props();
 
@@ -166,10 +169,25 @@
 						<Table.Cell>{new Date(email.sentAt).toLocaleString()}</Table.Cell>
 
 						<Table.Cell>
-							<div class="max-w-100 truncate">
-								<a class="link" href={`/dashboard/archived-emails/${email.id}`}>
-									{email.subject}
+							<div class="max-w-100 flex flex-wrap items-center gap-2">
+								<a
+									class="link min-w-0 truncate"
+									href={`/dashboard/archived-emails/${email.id}`}
+								>
+									{email.subject || $t('app.archive.no_subject')}
 								</a>
+								{#if email.encryptionStatus !== 'none'}
+									<Badge variant="secondary" class="gap-1 text-xs">
+										<LockKeyhole class="h-3 w-3" />
+										{$t('app.archive.encrypted')}
+									</Badge>
+								{/if}
+								{#if email.signatureStatus !== 'none'}
+									<Badge variant="outline" class="gap-1 text-xs">
+										<BadgeCheck class="h-3 w-3" />
+										{$t('app.archive.signed')}
+									</Badge>
+								{/if}
 							</div>
 						</Table.Cell>
 						<Table.Cell>

--- a/packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte
@@ -25,6 +25,8 @@
 		CircleAlert,
 		Tag,
 		FileDown,
+		LockKeyhole,
+		BadgeCheck,
 	} from 'lucide-svelte';
 	import { page } from '$app/state';
 	import { enhance } from '$app/forms';
@@ -278,7 +280,21 @@
 		<div class="col-span-3 md:col-span-2">
 			<Card.Root>
 				<Card.Header>
-					<Card.Title>{email.subject || $t('app.archive.no_subject')}</Card.Title>
+					<Card.Title class="flex flex-wrap items-center gap-2">
+						<span>{email.subject || $t('app.archive.no_subject')}</span>
+						{#if email.encryptionStatus !== 'none'}
+							<Badge variant="secondary" class="gap-1 text-xs">
+								<LockKeyhole class="h-3 w-3" />
+								{$t('app.archive.encrypted')}
+							</Badge>
+						{/if}
+						{#if email.signatureStatus !== 'none'}
+							<Badge variant="outline" class="gap-1 text-xs">
+								<BadgeCheck class="h-3 w-3" />
+								{$t('app.archive.signed')}
+							</Badge>
+						{/if}
+					</Card.Title>
 					<Card.Description>
 						{$t('app.archive.from')}: {email.senderName && email.senderEmail
 							? `${email.senderName} <${email.senderEmail}>`

--- a/packages/types/src/archived-emails.types.ts
+++ b/packages/types/src/archived-emails.types.ts
@@ -25,6 +25,15 @@ export interface ThreadEmail {
 	senderEmail: string;
 }
 
+export type EmailEncryptionStatus = 'none' | 'encrypted' | 'decrypted' | 'decrypt_failed';
+
+export type EmailSignatureStatus =
+	| 'none'
+	| 'signed_unverified'
+	| 'signed_valid'
+	| 'signed_invalid'
+	| 'signed_unverifiable';
+
 /**
  * Represents a single archived email.
  */
@@ -43,6 +52,8 @@ export interface ArchivedEmail {
 	storagePath: string;
 	storageHashSha256: string;
 	sizeBytes: number;
+	encryptionStatus: EmailEncryptionStatus;
+	signatureStatus: EmailSignatureStatus;
 	isIndexed: boolean;
 	/** Number of times indexing has been attempted and failed for this email.
 	 * Used by the reconcile job to stop retrying persistently-failing ("poison") emails. */


### PR DESCRIPTION
## Problem

Default-mode ingestion rebuilds every email through nodemailer's MailComposer to strip attachment bodies (`stripAttachmentsFromEml` in `packages/backend/src/helpers/emlUtils.ts`). For cryptographically enveloped mail this causes **irreversible data loss**:

- `application/(x-)pkcs7-mime` (S/MIME encrypted or opaque-signed): mailparser exposes no text body, so the rebuilt .eml is an **empty `text/plain`** — the ciphertext is discarded and the message can never be decrypted or recovered.
- `multipart/signed` (S/MIME detached or PGP/MIME signed): the rebuild re-serializes the signed content, permanently **breaking the signature**.
- `multipart/encrypted` (PGP/MIME): the encrypted payload is treated as an attachment and stripped.

Reproduced against openssl- and gpg-generated fixtures; both `application/pkcs7-mime` and the legacy `application/x-pkcs7-mime` spelling are affected.

## Fix

- **`detectCryptoEnvelope()`** — a small header-level detector (no crypto libraries, no MIME re-serialization) that classifies S/MIME enveloped / opaque-signed / detached-signed, PGP/MIME encrypted / signed, and inline PGP, including `smime-type` params, `x-pkcs7` variants, and `smime.p7m`/`.p7s`/`.p7c` filename fallbacks.
- **Byte-exact bypass** — any detected crypto envelope skips attachment stripping and is stored raw. The bypass is applied both at the ingestion call site and defensively inside `stripAttachmentsFromEml()` itself.
- **Status tracking** — new `email_encryption_status` / `email_signature_status` Postgres enums and `encryption_status` / `signature_status` columns on `archived_emails` (migration `0041`, default `'none'`, plus a partial index on non-`none` encryption states). Ingestion populates `encrypted` / `signed_unverified`; the extra enum values (`decrypted`, `signed_valid`, …) are reserved for a future decrypt/verify phase.
- **UI** — "Encrypted" / "Signed" badges on the archived-email list and detail views (i18n keys added to `en.json`).

## Notes

- No new runtime dependencies.
- Existing archives are unaffected (columns default to `'none'`); the partial index enables a later backfill/decrypt job.
- Test fixtures (including a throwaway RSA key/cert) are generated on demand by `gen-fixtures.sh` and gitignored.

## Test plan

- [x] `pnpm --filter backend test` — new suite: 12-case detection matrix (openssl `smime`+`cms` and gpg fixtures), byte-identical pass-through for 5 crypto envelope classes, and a regression check that normal mail is still stripped correctly
- [x] `pnpm --filter backend build` (tsc strict)
- [x] `svelte-check` — 0 errors / 0 warnings
- [ ] Manual: ingest an S/MIME-encrypted and a PGP/MIME-signed message, confirm stored .eml is byte-identical to source and badges render