### PR TITLE
fix(dashboard): Top Senders — accurate counts and no stacked bars

### DIFF
--- a/packages/backend/src/services/SearchService.ts
+++ b/packages/backend/src/services/SearchService.ts
@@ -484,6 +484,20 @@ export class SearchService {
 				'hasAttachments',
 			],
 			sortableAttributes: ['timestamp'],
+			// Faceting defaults in Meilisearch are hostile to our "Top N" widgets:
+			//   - maxValuesPerFacet defaults to 100
+			//   - sortFacetValuesBy defaults to 'alpha' (lexicographic)
+			// So a facetDistribution over `from` returns only the alphabetically-first
+			// 100 senders out of the (many thousands of) distinct addresses in a large
+			// archive. getTopSenders() then sorts THAT arbitrary slice by count, which
+			// surfaces the top of an alphabetical subset — not the real top senders
+			// (observed: max count of ~25 across a 200k-email index). Sorting facet
+			// values by count makes Meilisearch return the highest-frequency values,
+			// so getTopSenders / getFacetValues see the true leaders.
+			faceting: {
+				maxValuesPerFacet: 1000,
+				sortFacetValuesBy: { '*': 'count' },
+			},
 		});
 	}
 }

--- a/packages/backend/src/services/SearchService.ts
+++ b/packages/backend/src/services/SearchService.ts
@@ -528,6 +528,20 @@ export class SearchService {
 				'hasAttachments',
 			],
 			sortableAttributes: ['timestamp'],
+			// Faceting defaults in Meilisearch are hostile to our "Top N" widgets:
+			//   - maxValuesPerFacet defaults to 100
+			//   - sortFacetValuesBy defaults to 'alpha' (lexicographic)
+			// So a facetDistribution over `from` returns only the alphabetically-first
+			// 100 senders out of the (many thousands of) distinct addresses in a large
+			// archive. getTopSenders() then sorts THAT arbitrary slice by count, which
+			// surfaces the top of an alphabetical subset — not the real top senders
+			// (observed: max count of ~25 across a 200k-email index). Sorting facet
+			// values by count makes Meilisearch return the highest-frequency values,
+			// so getTopSenders / getFacetValues see the true leaders.
+			faceting: {
+				maxValuesPerFacet: 1000,
+				sortFacetValuesBy: { '*': 'count' },
+			},
 		});
 	}
 }

--- a/packages/frontend/src/lib/components/custom/charts/TopSendersChart.svelte
+++ b/packages/frontend/src/lib/components/custom/charts/TopSendersChart.svelte
@@ -8,7 +8,22 @@
 	export let data: TopSender[];
 
 	// Show the resolved display name when known, falling back to the address (#413).
-	$: chartData = data.map((d) => ({ ...d, sender: d.senderName || d.sender }));
+	// The chart keys each bar on `sender` (the y-axis category), so it MUST be
+	// unique per row — layerchart bands rows sharing a y value into a single
+	// stacked bar. Two distinct addresses can resolve to the same display name
+	// (e.g. two facebookmail.com addresses both named "Facebook"), so when a name
+	// is shared we disambiguate it with the (unique) address to keep them as
+	// separate bars instead of one stacked row.
+	$: nameCounts = data.reduce((acc, d) => {
+		const name = d.senderName || d.sender;
+		acc.set(name, (acc.get(name) ?? 0) + 1);
+		return acc;
+	}, new Map<string, number>());
+	$: chartData = data.map((d) => {
+		const name = d.senderName || d.sender;
+		const label = nameCounts.get(name)! > 1 && d.senderName ? `${name} (${d.sender})` : name;
+		return { ...d, sender: label };
+	});
 
 	const chartConfig = {
 		count: {

--- a/packages/frontend/src/lib/components/custom/charts/TopSendersChart.svelte
+++ b/packages/frontend/src/lib/components/custom/charts/TopSendersChart.svelte
@@ -9,7 +9,22 @@
 	export let data: TopSender[];
 
 	// Show the resolved display name when known, falling back to the address (#413).
-	$: chartData = data.map((d) => ({ ...d, sender: d.senderName || d.sender }));
+	// The chart keys each bar on `sender` (the y-axis category), so it MUST be
+	// unique per row — layerchart bands rows sharing a y value into a single
+	// stacked bar. Two distinct addresses can resolve to the same display name
+	// (e.g. two facebookmail.com addresses both named "Facebook"), so when a name
+	// is shared we disambiguate it with the (unique) address to keep them as
+	// separate bars instead of one stacked row.
+	$: nameCounts = data.reduce((acc, d) => {
+		const name = d.senderName || d.sender;
+		acc.set(name, (acc.get(name) ?? 0) + 1);
+		return acc;
+	}, new Map<string, number>());
+	$: chartData = data.map((d) => {
+		const name = d.senderName || d.sender;
+		const label = nameCounts.get(name)! > 1 && d.senderName ? `${name} (${d.sender})` : name;
+		return { ...d, sender: label };
+	});
 
 	$: axisMax = niceAxisMax(Math.max(...chartData.map((d) => d.count)));
 


### PR DESCRIPTION
Two related fixes for the dashboard's **Top 10 Senders** widget.

---

## 1. Counts were wildly inaccurate (backend)

### Problem
On a ~200k-email archive the top bar maxed out around 25 — effectively a random/low
set of senders rather than the real leaders.

### Root cause
`SearchService.getTopSenders()` reads Meilisearch's `from` facet distribution
(`index.search('', { facets: ['from'] })`). But `configureEmailIndex()` never set any
`faceting` config, so Meilisearch applied its defaults:

- `maxValuesPerFacet: 100` — only 100 of the many thousands of distinct senders are returned
- `sortFacetValuesBy: 'alpha'` — those 100 are the **alphabetically-first** addresses, not the most frequent

`getTopSenders()` then sorted that arbitrary alphabetical slice by count and took the
top 10 — surfacing the top of an alphabetical subset, never the true high-volume
senders. The same defect affected `getFacetValues()` (facet typeahead suggestions).

### Fix
Configure faceting on the emails index to sort facet values by count and raise the cap:

```ts
faceting: {
    maxValuesPerFacet: 1000,
    sortFacetValuesBy: { '*': 'count' },
},
```

Meilisearch now returns the highest-frequency facet values, so the widget sees the
real leaders. Settings-only change, applied at startup via `configureEmailIndex()` —
**no reindex required**.

### Verification
Ran against a live ~200k-email index; Meilisearch's facet distribution now matches the
Postgres ground truth almost exactly (Amazon 8,338 vs 8,340, Facebook 7,178 vs 7,179, …).

---

## 2. Two senders rendered as one stacked bar (frontend)

### Problem
Two senders sometimes rendered as a single stacked bar (e.g. a "Facebook" row showing
1,925 + 4,832 in one bar) instead of two separate bars.

### Root cause
`TopSendersChart.svelte` keys each bar on `sender` — the y-axis category — after
overwriting it with the resolved display name (`senderName || address`). Facet values
(addresses) are unique, but two distinct addresses can resolve to the **same** display
name (`notification+…@facebookmail.com` and `update+…@facebookmail.com` both → "Facebook").
Sharing a y value makes layerchart band them into one stacked bar.

### Fix
Disambiguate the category: keep the bare name only when it's unique among the top
senders; when a name is shared, append the (unique) address so each sender keeps its
own bar. Bare unique names (Amazon.com, LinkedIn, …) are unchanged.