### PR TITLE
V0.6.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "open-archiver",
-	"version": "0.5.3",
+	"version": "0.6.0",
 	"private": true,
 	"license": "SEE LICENSE IN LICENSE file",
 	"scripts": {

--- a/packages/backend/src/jobs/processors/continuous-sync.processor.ts
+++ b/packages/backend/src/jobs/processors/continuous-sync.processor.ts
@@ -24,30 +24,39 @@ export default async (job: Job<IContinuousSyncJob>) => {
 		return;
 	}
 
-	const connector = EmailProviderFactory.createConnector(source);
-
-	// One-shot provider-id backfill for Microsoft 365 sources (see the processor). The fixed
-	// jobId keeps it to one instance while a run is queued or active; the syncState flag is
-	// what ends the re-enqueueing once a run has succeeded. removeOnFail is load-bearing, not
-	// hygiene: BullMQ silently drops an add whose jobId matches ANY surviving record, and the
-	// queue's defaults retain failed records by count — so without it, one transient failure
-	// would park a dead record under this id and every later cycle's add would be dropped
-	// against it (the trap claimJobId documents). Removing terminal records instead makes a
-	// failed run retry naturally on the next cycle, until the flag stops the loop.
-	if (source.provider === 'microsoft_365' && !source.syncState?.providerIdBackfillCompletedAt) {
-		await ingestionQueue.add(
-			'backfill-provider-ids',
-			{ ingestionSourceId },
-			{
-				jobId: `backfill-provider-ids-${ingestionSourceId}`,
-				attempts: 1,
-				removeOnComplete: true,
-				removeOnFail: true,
-			}
-		);
-	}
-
+	// EVERYTHING after a successful claim runs inside this try. The claim put the source into
+	// 'syncing', which only the catch below (status: 'error') or a finished cycle can undo — a
+	// throw that escapes between claim and catch strands the source in 'syncing' with no error,
+	// no session, and no log, and the scheduler never admits it again. That is not hypothetical:
+	// connector construction throws synchronously on damaged credentials (MSAL validates its
+	// config), and exactly that left a source dead on a production instance.
 	try {
+		const connector = EmailProviderFactory.createConnector(source);
+
+		// One-shot provider-id backfill for Microsoft 365 sources (see the processor). The fixed
+		// jobId keeps it to one instance while a run is queued or active; the syncState flag is
+		// what ends the re-enqueueing once a run has succeeded. removeOnFail is load-bearing, not
+		// hygiene: BullMQ silently drops an add whose jobId matches ANY surviving record, and the
+		// queue's defaults retain failed records by count — so without it, one transient failure
+		// would park a dead record under this id and every later cycle's add would be dropped
+		// against it (the trap claimJobId documents). Removing terminal records instead makes a
+		// failed run retry naturally on the next cycle, until the flag stops the loop.
+		if (
+			source.provider === 'microsoft_365' &&
+			!source.syncState?.providerIdBackfillCompletedAt
+		) {
+			await ingestionQueue.add(
+				'backfill-provider-ids',
+				{ ingestionSourceId },
+				{
+					jobId: `backfill-provider-ids-${ingestionSourceId}`,
+					attempts: 1,
+					removeOnComplete: true,
+					removeOnFail: true,
+				}
+			);
+		}
+
 		// Phase 1: Collect user emails (async generator — no full buffering of job descriptors).
 		// We need the total count before creating the session so the counter is correct.
 		const userEmails: string[] = [];

--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -28,6 +28,7 @@ import {
 import { CryptoService } from './CryptoService';
 import { EmailProviderFactory } from './EmailProviderFactory';
 import { mergeOAuthCredentials, validateOAuthMailboxConfig } from './oauth/oauthHelpers';
+import { mergeProviderCredentials } from './credentialMerge';
 import { ingestionQueue, indexingQueue } from '../jobs/queues';
 import { continuousSyncJobId, initialImportJobId } from '../jobs/helpers/jobIds';
 import { claimJobId } from '../jobs/helpers/claimJobId';
@@ -429,8 +430,17 @@ export class IngestionService {
 				}
 				valuesToUpdate.credentials = CryptoService.encryptObject(merged);
 			} else {
-				// Encrypt the new credentials before updating
-				valuesToUpdate.credentials = CryptoService.encryptObject(providerConfig);
+				// The edit form starts blank for every provider (SafeIngestionSource omits
+				// credentials), so what arrives here is not the new truth — it is whatever
+				// the admin typed over a form that could not show the old values. Merging
+				// keeps stored fields wherever the incoming ones are blank; storing the
+				// incoming object wholesale is how a rename-only edit once wiped a working
+				// Microsoft 365 source down to two IMAP form defaults.
+				const result = mergeProviderCredentials(originalSource.credentials, providerConfig);
+				if (!result.ok) {
+					throw new Error(result.message);
+				}
+				valuesToUpdate.credentials = CryptoService.encryptObject(result.merged);
 			}
 		}
 

--- a/packages/backend/src/services/credentialMerge.ts
+++ b/packages/backend/src/services/credentialMerge.ts
@@ -1,0 +1,106 @@
+import type { IngestionCredentials, IngestionProvider } from '@open-archiver/types';
+
+/**
+ * Merge rules for editing a non-OAuth ingestion source's credentials.
+ *
+ * The edit dialog can never show what is stored (SafeIngestionSource strips credentials), so
+ * what arrives from it is whatever the admin typed into a blank form — usually nothing. Until
+ * this helper existed, IngestionService.update stored that blank object wholesale, and a
+ * rename-only edit destroyed a working source's secrets: one production Microsoft 365 source
+ * was left holding `{type, secure, allowInsecureCert}` — no client id, no tenant, no secret,
+ * plus two IMAP form defaults that leaked in from the dialog's initial state.
+ *
+ * The rules mirror mergeOAuthCredentials, which already protects oauth_mailbox:
+ *
+ * - Only the provider's own fields are read from the incoming config; stray keys from other
+ *   providers' form sections are dropped, never stored.
+ * - An incoming field that is undefined or '' keeps the stored value. Blank means "the form
+ *   could not show it", never "erase it". `false` and `0` are real values and pass through.
+ * - Changing the provider type replaces the credentials outright, but only when the incoming
+ *   config is complete for the new provider — a half-filled provider switch is exactly what
+ *   produced the destroyed source above.
+ */
+
+/** Every field a provider's credentials may carry. Anything else from the client is dropped. */
+const PROVIDER_FIELDS: Partial<Record<IngestionProvider, readonly string[]>> = {
+	generic_imap: ['host', 'port', 'secure', 'allowInsecureCert', 'username', 'password'],
+	microsoft_365: ['clientId', 'clientSecret', 'tenantId'],
+	google_workspace: ['serviceAccountKeyJson', 'impersonatedAdminEmail'],
+	pst_import: ['uploadedFileName', 'uploadedFilePath', 'localFilePath'],
+	eml_import: ['uploadedFileName', 'uploadedFilePath', 'localFilePath'],
+	mbox_import: ['uploadedFileName', 'uploadedFilePath', 'localFilePath'],
+};
+
+/** The fields that must be non-empty after the merge for the source to be able to connect. */
+const REQUIRED_FIELDS: Partial<Record<IngestionProvider, readonly string[]>> = {
+	generic_imap: ['host', 'username', 'password'],
+	microsoft_365: ['clientId', 'clientSecret', 'tenantId'],
+	google_workspace: ['serviceAccountKeyJson', 'impersonatedAdminEmail'],
+};
+
+const isBlank = (value: unknown): boolean => value === undefined || value === '';
+
+const missingFields = (config: Record<string, any>, provider: IngestionProvider): string[] =>
+	(REQUIRED_FIELDS[provider] ?? []).filter((field) => isBlank(config[field]));
+
+export type CredentialMergeResult =
+	| { ok: true; merged: Record<string, any> }
+	| { ok: false; message: string };
+
+/**
+ * Produces the credentials an edit should store, or the reason it must be refused.
+ *
+ * `oauth_mailbox` never reaches here — IngestionService.update routes it to
+ * mergeOAuthCredentials first — and a provider this table does not know keeps the historical
+ * replace-wholesale behavior rather than guessing at its field semantics.
+ */
+export const mergeProviderCredentials = (
+	original: IngestionCredentials,
+	incoming: Record<string, any>
+): CredentialMergeResult => {
+	const incomingType: IngestionProvider =
+		typeof incoming.type === 'string' && incoming.type !== ''
+			? (incoming.type as IngestionProvider)
+			: original.type;
+
+	const fields = PROVIDER_FIELDS[incomingType];
+	if (!fields) {
+		return { ok: true, merged: { ...incoming, type: incomingType } };
+	}
+
+	if (incomingType !== original.type) {
+		// A provider switch may not inherit anything: the old fields mean nothing to the new
+		// connector, so the incoming config must stand entirely on its own.
+		const replaced: Record<string, any> = { type: incomingType };
+		for (const field of fields) {
+			if (!isBlank(incoming[field])) {
+				replaced[field] = incoming[field];
+			}
+		}
+		const missing = missingFields(replaced, incomingType);
+		if (missing.length > 0) {
+			return {
+				ok: false,
+				message:
+					`Changing the provider requires complete connection settings. ` +
+					`Missing: ${missing.join(', ')}`,
+			};
+		}
+		return { ok: true, merged: replaced };
+	}
+
+	const merged: Record<string, any> = { type: incomingType };
+	for (const field of fields) {
+		const value = isBlank(incoming[field])
+			? (original as Record<string, any>)[field]
+			: incoming[field];
+		if (value !== undefined) {
+			merged[field] = value;
+		}
+	}
+	const missing = missingFields(merged, incomingType);
+	if (missing.length > 0) {
+		return { ok: false, message: `Missing required connection fields: ${missing.join(', ')}` };
+	}
+	return { ok: true, merged };
+};

--- a/packages/frontend/src/lib/components/custom/IngestionSourceForm.svelte
+++ b/packages/frontend/src/lib/components/custom/IngestionSourceForm.svelte
@@ -174,10 +174,23 @@
 	/**
 	 * Edit mode ships no stored credentials (SafeIngestionSource omits them), so the
 	 * connection fields would arrive blank and any save would read as changing them —
-	 * which invalidates the tokens. Keeping the fields behind this toggle lets a plain
-	 * rename skip providerConfig entirely; the server-side merge guards the rest.
+	 * for an OAuth source that invalidates the tokens, and for every other provider it
+	 * used to overwrite the stored secrets with the blanks. Keeping the fields behind
+	 * this toggle lets a plain rename skip providerConfig entirely; the server-side
+	 * merge guards whatever does get sent.
 	 */
-	let oauthEditConnection = $state(false);
+	let editConnection = $state(false);
+
+	/** The providers whose credentials the edit dialog must not silently resubmit. */
+	const CREDENTIALED_PROVIDERS = [
+		'google_workspace',
+		'microsoft_365',
+		'generic_imap',
+		'oauth_mailbox',
+	];
+	const showConnectionFields = $derived(
+		!source || !CREDENTIALED_PROVIDERS.includes(formData.provider) || editConnection
+	);
 
 	/**
 	 * The redirect URI to register with the OAuth provider.
@@ -276,10 +289,11 @@
 		event.preventDefault();
 		isSubmitting = true;
 		try {
-			// An oauth_mailbox edit that leaves the connection alone must not send
-			// providerConfig at all — the form's copy is blank, and the backend treats an
-			// arriving providerConfig as the new truth.
-			if (source && formData.provider === 'oauth_mailbox' && !oauthEditConnection) {
+			// An edit that leaves the connection alone must not send providerConfig at
+			// all — the form's copy is blank, and blanks are not an instruction to erase.
+			// The backend merge is the safety net; omitting the object entirely is the
+			// guarantee.
+			if (source && !showConnectionFields) {
 				const { providerConfig, ...withoutConfig } = formData;
 				await onSubmit(withoutConfig as CreateIngestionSourceDto);
 			} else {
@@ -470,11 +484,15 @@
 	</div>
 	<div class="grid grid-cols-4 items-center gap-4">
 		<Label for="provider" class="text-left">{$t('app.ingestions.provider')}</Label>
+		<!-- Editing cannot change the provider: the dialog cannot show the stored
+		     credentials, so a switch could only ever submit a half-blank config for the
+		     new type. A different provider is a new source. -->
 		<Select.Root
 			name="provider"
 			bind:value={formData.provider}
 			onValueChange={handleProviderChange}
 			type="single"
+			disabled={!!source}
 		>
 			<Select.Trigger class="col-span-3">
 				{triggerContent}
@@ -489,7 +507,26 @@
 		</Select.Root>
 	</div>
 
-	{#if formData.provider === 'google_workspace'}
+	{#if source && CREDENTIALED_PROVIDERS.includes(formData.provider)}
+		<!-- The connection fields stay hidden (and unsent) until explicitly opened. -->
+		{#if !editConnection}
+			<Alert.Root>
+				<Alert.Description>
+					{formData.provider === 'oauth_mailbox'
+						? $t('app.components.ingestion_source_form.oauth_edit_connection_warning')
+						: $t('app.components.ingestion_source_form.edit_connection_warning')}
+				</Alert.Description>
+			</Alert.Root>
+		{/if}
+		<div class="grid grid-cols-4 items-center gap-4">
+			<Label for="editConnection" class="text-left"
+				>{$t('app.components.ingestion_source_form.oauth_edit_connection_toggle')}</Label
+			>
+			<Checkbox id="editConnection" bind:checked={editConnection} />
+		</div>
+	{/if}
+
+	{#if formData.provider === 'google_workspace' && showConnectionFields}
 		<div class="grid grid-cols-4 items-center gap-4">
 			<Label for="serviceAccountKeyJson" class="text-left"
 				>{$t('app.components.ingestion_source_form.service_account_key')}</Label
@@ -513,7 +550,7 @@
 				class="col-span-3"
 			/>
 		</div>
-	{:else if formData.provider === 'microsoft_365'}
+	{:else if formData.provider === 'microsoft_365' && showConnectionFields}
 		<div class="grid grid-cols-4 items-center gap-4">
 			<Label for="clientId" class="text-left"
 				>{$t('app.components.ingestion_source_form.client_id')}</Label
@@ -538,7 +575,7 @@
 			>
 			<Input id="tenantId" bind:value={formData.providerConfig.tenantId} class="col-span-3" />
 		</div>
-	{:else if formData.provider === 'generic_imap'}
+	{:else if formData.provider === 'generic_imap' && showConnectionFields}
 		<div class="grid grid-cols-4 items-center gap-4">
 			<Label for="host" class="text-left"
 				>{$t('app.components.ingestion_source_form.host')}</Label
@@ -586,231 +623,196 @@
 				bind:checked={formData.providerConfig.allowInsecureCert}
 			/>
 		</div>
-	{:else if formData.provider === 'oauth_mailbox'}
-		{#if source && !oauthEditConnection}
-			<!-- Editing: connection stays untouched unless explicitly opened. -->
-			<Alert.Root>
-				<Alert.Description>
-					{$t('app.components.ingestion_source_form.oauth_edit_connection_warning')}
-				</Alert.Description>
-			</Alert.Root>
-			<div class="grid grid-cols-4 items-center gap-4">
-				<Label for="oauthEditConnection" class="text-left"
-					>{$t(
-						'app.components.ingestion_source_form.oauth_edit_connection_toggle'
-					)}</Label
+	{:else if formData.provider === 'oauth_mailbox' && showConnectionFields}
+		<div class="grid grid-cols-4 items-center gap-4">
+			<Label class="text-left"
+				>{$t('app.components.ingestion_source_form.oauth_preset')}</Label
+			>
+			<div class="col-span-3">
+				<Select.Root
+					type="single"
+					value={formData.providerConfig.preset}
+					onValueChange={(value) => value && applyOauthPreset(value)}
 				>
-				<Checkbox id="oauthEditConnection" bind:checked={oauthEditConnection} />
+					<Select.Trigger class="w-full">
+						{oauthPresetLabel(formData.providerConfig.preset)}
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="outlook"
+							>{$t(
+								'app.components.ingestion_source_form.oauth_preset_outlook'
+							)}</Select.Item
+						>
+						<Select.Item value="microsoft_work"
+							>{$t(
+								'app.components.ingestion_source_form.oauth_preset_microsoft_work'
+							)}</Select.Item
+						>
+						<Select.Item value="custom"
+							>{$t(
+								'app.components.ingestion_source_form.oauth_preset_custom'
+							)}</Select.Item
+						>
+					</Select.Content>
+				</Select.Root>
+				<p class="text-muted-foreground mt-1 text-xs">
+					{formData.providerConfig.transport === 'graph'
+						? $t('app.components.ingestion_source_form.oauth_transport_graph_hint')
+						: $t('app.components.ingestion_source_form.oauth_transport_imap_hint')}
+				</p>
 			</div>
-		{:else}
-			{#if source}
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthEditConnection" class="text-left"
-						>{$t(
-							'app.components.ingestion_source_form.oauth_edit_connection_toggle'
-						)}</Label
-					>
-					<Checkbox id="oauthEditConnection" bind:checked={oauthEditConnection} />
-				</div>
-			{/if}
-			<div class="grid grid-cols-4 items-center gap-4">
-				<Label class="text-left"
-					>{$t('app.components.ingestion_source_form.oauth_preset')}</Label
-				>
-				<div class="col-span-3">
-					<Select.Root
-						type="single"
-						value={formData.providerConfig.preset}
-						onValueChange={(value) => value && applyOauthPreset(value)}
-					>
-						<Select.Trigger class="w-full">
-							{oauthPresetLabel(formData.providerConfig.preset)}
-						</Select.Trigger>
-						<Select.Content>
-							<Select.Item value="outlook"
-								>{$t(
-									'app.components.ingestion_source_form.oauth_preset_outlook'
-								)}</Select.Item
-							>
-							<Select.Item value="microsoft_work"
-								>{$t(
-									'app.components.ingestion_source_form.oauth_preset_microsoft_work'
-								)}</Select.Item
-							>
-							<Select.Item value="custom"
-								>{$t(
-									'app.components.ingestion_source_form.oauth_preset_custom'
-								)}</Select.Item
-							>
-						</Select.Content>
-					</Select.Root>
-					<p class="text-muted-foreground mt-1 text-xs">
-						{formData.providerConfig.transport === 'graph'
-							? $t('app.components.ingestion_source_form.oauth_transport_graph_hint')
-							: $t('app.components.ingestion_source_form.oauth_transport_imap_hint')}
-					</p>
-				</div>
-			</div>
-			<div class="grid grid-cols-4 items-start gap-4">
-				<Label class="pt-2 text-left"
-					>{$t('app.components.ingestion_source_form.oauth_flow')}</Label
-				>
-				<RadioGroup.Root bind:value={formData.providerConfig.flow} class="col-span-3">
-					<div class="flex items-start gap-2">
-						<RadioGroup.Item value="auth_code" id="oauth-flow-auth-code" class="mt-1" />
-						<div>
-							<Label for="oauth-flow-auth-code"
-								>{$t(
-									'app.components.ingestion_source_form.oauth_flow_auth_code'
-								)}</Label
-							>
-							<p class="text-muted-foreground text-xs">
-								{$t(
-									'app.components.ingestion_source_form.oauth_flow_auth_code_hint'
-								)}
-							</p>
-						</div>
+		</div>
+		<div class="grid grid-cols-4 items-start gap-4">
+			<Label class="pt-2 text-left"
+				>{$t('app.components.ingestion_source_form.oauth_flow')}</Label
+			>
+			<RadioGroup.Root bind:value={formData.providerConfig.flow} class="col-span-3">
+				<div class="flex items-start gap-2">
+					<RadioGroup.Item value="auth_code" id="oauth-flow-auth-code" class="mt-1" />
+					<div>
+						<Label for="oauth-flow-auth-code"
+							>{$t(
+								'app.components.ingestion_source_form.oauth_flow_auth_code'
+							)}</Label
+						>
+						<p class="text-muted-foreground text-xs">
+							{$t('app.components.ingestion_source_form.oauth_flow_auth_code_hint')}
+						</p>
 					</div>
-					<div class="flex items-start gap-2">
-						<RadioGroup.Item
-							value="device_code"
-							id="oauth-flow-device-code"
-							class="mt-1"
-						/>
-						<div>
-							<Label for="oauth-flow-device-code"
-								>{$t(
-									'app.components.ingestion_source_form.oauth_flow_device_code'
-								)}</Label
-							>
-							<p class="text-muted-foreground text-xs">
-								{$t(
-									'app.components.ingestion_source_form.oauth_flow_device_code_hint'
-								)}
-							</p>
-						</div>
+				</div>
+				<div class="flex items-start gap-2">
+					<RadioGroup.Item value="device_code" id="oauth-flow-device-code" class="mt-1" />
+					<div>
+						<Label for="oauth-flow-device-code"
+							>{$t(
+								'app.components.ingestion_source_form.oauth_flow_device_code'
+							)}</Label
+						>
+						<p class="text-muted-foreground text-xs">
+							{$t('app.components.ingestion_source_form.oauth_flow_device_code_hint')}
+						</p>
 					</div>
-				</RadioGroup.Root>
-			</div>
-			<div class="grid grid-cols-4 items-center gap-4">
-				<Label for="oauthEmail" class="text-left"
-					>{$t('app.components.ingestion_source_form.oauth_email')}</Label
-				>
-				<Input
-					id="oauthEmail"
-					type="email"
-					bind:value={formData.providerConfig.email}
-					class="col-span-3"
-					placeholder="mailbox@outlook.com"
-				/>
-			</div>
-			<div class="grid grid-cols-4 items-center gap-4">
-				<Label for="oauthClientId" class="text-left"
-					>{$t('app.components.ingestion_source_form.client_id')}</Label
-				>
-				<Input
-					id="oauthClientId"
-					bind:value={formData.providerConfig.clientId}
-					class="col-span-3"
-				/>
-			</div>
-			<!-- The device-code flow is a public-client flow: a secret is neither needed nor
+				</div>
+			</RadioGroup.Root>
+		</div>
+		<div class="grid grid-cols-4 items-center gap-4">
+			<Label for="oauthEmail" class="text-left"
+				>{$t('app.components.ingestion_source_form.oauth_email')}</Label
+			>
+			<Input
+				id="oauthEmail"
+				type="email"
+				bind:value={formData.providerConfig.email}
+				class="col-span-3"
+				placeholder="mailbox@outlook.com"
+			/>
+		</div>
+		<div class="grid grid-cols-4 items-center gap-4">
+			<Label for="oauthClientId" class="text-left"
+				>{$t('app.components.ingestion_source_form.client_id')}</Label
+			>
+			<Input
+				id="oauthClientId"
+				bind:value={formData.providerConfig.clientId}
+				class="col-span-3"
+			/>
+		</div>
+		<!-- The device-code flow is a public-client flow: a secret is neither needed nor
 			     wanted, and Microsoft's own guidance is not to create one. Asking for it here
 			     invites an admin to register the app as a confidential client, which then
 			     fails the flow it was meant to help. -->
-			{#if formData.providerConfig.flow !== 'device_code'}
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthClientSecret" class="text-left"
-						>{$t('app.components.ingestion_source_form.client_secret')}</Label
-					>
-					<Input
-						id="oauthClientSecret"
-						type="password"
-						bind:value={formData.providerConfig.clientSecret}
-						class="col-span-3"
-						placeholder={$t(
-							'app.components.ingestion_source_form.oauth_client_secret_placeholder'
-						)}
-					/>
-				</div>
-			{/if}
-			{#if formData.providerConfig.preset === 'custom'}
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthAuthEndpoint" class="text-left"
-						>{$t(
-							'app.components.ingestion_source_form.oauth_authorization_endpoint'
-						)}</Label
-					>
-					<Input
-						id="oauthAuthEndpoint"
-						bind:value={formData.providerConfig.authorizationEndpoint}
-						class="col-span-3"
-					/>
-				</div>
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthTokenEndpoint" class="text-left"
-						>{$t('app.components.ingestion_source_form.oauth_token_endpoint')}</Label
-					>
-					<Input
-						id="oauthTokenEndpoint"
-						bind:value={formData.providerConfig.tokenEndpoint}
-						class="col-span-3"
-					/>
-				</div>
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthDeviceEndpoint" class="text-left"
-						>{$t('app.components.ingestion_source_form.oauth_device_endpoint')}</Label
-					>
-					<Input
-						id="oauthDeviceEndpoint"
-						bind:value={formData.providerConfig.deviceAuthorizationEndpoint}
-						class="col-span-3"
-					/>
-				</div>
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthScopes" class="text-left"
-						>{$t('app.components.ingestion_source_form.oauth_scopes')}</Label
-					>
-					<Input
-						id="oauthScopes"
-						bind:value={formData.providerConfig.scopes}
-						class="col-span-3"
-					/>
-				</div>
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthImapHost" class="text-left"
-						>{$t('app.components.ingestion_source_form.oauth_imap_host')}</Label
-					>
-					<Input
-						id="oauthImapHost"
-						bind:value={formData.providerConfig.imapHost}
-						class="col-span-3"
-					/>
-				</div>
-				<div class="grid grid-cols-4 items-center gap-4">
-					<Label for="oauthImapPort" class="text-left"
-						>{$t('app.components.ingestion_source_form.oauth_imap_port')}</Label
-					>
-					<Input
-						id="oauthImapPort"
-						type="number"
-						bind:value={formData.providerConfig.imapPort}
-						class="col-span-3"
-					/>
-				</div>
-			{/if}
-			{#if formData.providerConfig.flow === 'auth_code'}
-				<Alert.Root>
-					<Alert.Description>
-						<div class="my-1">
-							{$t('app.components.ingestion_source_form.oauth_redirect_uri_note')}
-							<code class="bg-muted mt-1 block break-all rounded px-1 py-0.5 text-xs"
-								>{resolvedRedirectUri}</code
-							>
-						</div>
-					</Alert.Description>
-				</Alert.Root>
-			{/if}
+		{#if formData.providerConfig.flow !== 'device_code'}
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthClientSecret" class="text-left"
+					>{$t('app.components.ingestion_source_form.client_secret')}</Label
+				>
+				<Input
+					id="oauthClientSecret"
+					type="password"
+					bind:value={formData.providerConfig.clientSecret}
+					class="col-span-3"
+					placeholder={$t(
+						'app.components.ingestion_source_form.oauth_client_secret_placeholder'
+					)}
+				/>
+			</div>
+		{/if}
+		{#if formData.providerConfig.preset === 'custom'}
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthAuthEndpoint" class="text-left"
+					>{$t(
+						'app.components.ingestion_source_form.oauth_authorization_endpoint'
+					)}</Label
+				>
+				<Input
+					id="oauthAuthEndpoint"
+					bind:value={formData.providerConfig.authorizationEndpoint}
+					class="col-span-3"
+				/>
+			</div>
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthTokenEndpoint" class="text-left"
+					>{$t('app.components.ingestion_source_form.oauth_token_endpoint')}</Label
+				>
+				<Input
+					id="oauthTokenEndpoint"
+					bind:value={formData.providerConfig.tokenEndpoint}
+					class="col-span-3"
+				/>
+			</div>
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthDeviceEndpoint" class="text-left"
+					>{$t('app.components.ingestion_source_form.oauth_device_endpoint')}</Label
+				>
+				<Input
+					id="oauthDeviceEndpoint"
+					bind:value={formData.providerConfig.deviceAuthorizationEndpoint}
+					class="col-span-3"
+				/>
+			</div>
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthScopes" class="text-left"
+					>{$t('app.components.ingestion_source_form.oauth_scopes')}</Label
+				>
+				<Input
+					id="oauthScopes"
+					bind:value={formData.providerConfig.scopes}
+					class="col-span-3"
+				/>
+			</div>
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthImapHost" class="text-left"
+					>{$t('app.components.ingestion_source_form.oauth_imap_host')}</Label
+				>
+				<Input
+					id="oauthImapHost"
+					bind:value={formData.providerConfig.imapHost}
+					class="col-span-3"
+				/>
+			</div>
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label for="oauthImapPort" class="text-left"
+					>{$t('app.components.ingestion_source_form.oauth_imap_port')}</Label
+				>
+				<Input
+					id="oauthImapPort"
+					type="number"
+					bind:value={formData.providerConfig.imapPort}
+					class="col-span-3"
+				/>
+			</div>
+		{/if}
+		{#if formData.providerConfig.flow === 'auth_code'}
+			<Alert.Root>
+				<Alert.Description>
+					<div class="my-1">
+						{$t('app.components.ingestion_source_form.oauth_redirect_uri_note')}
+						<code class="bg-muted mt-1 block break-all rounded px-1 py-0.5 text-xs"
+							>{resolvedRedirectUri}</code
+						>
+					</div>
+				</Alert.Description>
+			</Alert.Root>
 		{/if}
 	{:else if formData.provider === 'pst_import'}
 		<div class="grid grid-cols-4 items-start gap-4">

--- a/packages/frontend/src/lib/translations/en.json
+++ b/packages/frontend/src/lib/translations/en.json
@@ -423,6 +423,7 @@
 				"oauth_imap_port": "IMAP port",
 				"oauth_redirect_uri_note": "Register this redirect URI in your OAuth app registration:",
 				"oauth_edit_connection_toggle": "Update connection settings",
+				"edit_connection_warning": "The connection settings and stored credentials are left unchanged. Turn on \u201cUpdate connection settings\u201d to change them \u2014 fields left blank keep their stored values.",
 				"oauth_edit_connection_warning": "The mailbox connection and its authorization are left unchanged. Turn on “Update connection settings” to change them — the mailbox will then need to be re-authorized."
 			},
 			"role_form": {


### PR DESCRIPTION
…iled syncs hanging in "syncing"

Editing an ingestion source sent the form's blank connection fields to the server, which stored them as-is. Because the edit dialog can never display stored credentials, even a plain rename replaced a working source's secrets with blanks, and the source could no longer sign in. One Microsoft 365 source in production was broken exactly this way.

- Edits now merge instead of replace: a field left blank keeps its stored value, secrets included, for IMAP, Microsoft 365 and Google Workspace sources alike. OAuth Mailbox sources already worked this way.
- The connection fields of an existing source sit behind an "Update connection settings" switch, and a rename sends no connection data at all.
- The provider of an existing source can no longer be changed from the edit dialog; via the API it now requires complete settings for the new provider.
- A source whose credentials cannot even construct a connector used to hang in "syncing" with no error and no log, because the failure happened before the error handling was reached. Such failures now mark the source as "error" with the real message, and the next cycle retries it.