### PR TITLE
fix(ingestion): sanitize NUL and unpaired surrogates before insert

### DIFF
--- a/packages/backend/src/services/IngestionService.ts
+++ b/packages/backend/src/services/IngestionService.ts
@@ -88,6 +88,28 @@ const normalizedMailbox = sql<string>`lower(btrim(${archivedEmails.userEmail}))`
  */
 const matchesMailbox = (normalizedAddress: string) => eq(normalizedMailbox, normalizedAddress);
 
+// Strip characters that Postgres TEXT columns reject (code 22021,
+// "invalid byte sequence for encoding UTF8"): NUL (U+0000) and unpaired
+// UTF-16 surrogates. Some IMAP/MIME-parsed emails contain these in headers
+// or decoded bodies and would otherwise abort the whole row insert.
+function stripUnsafeChars(s: string): string {
+	// Drop NULs (Postgres TEXT rejects U+0000), then replace lone surrogates with U+FFFD.
+	return s
+		.replace(/\x00/g, '')
+		.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '�');
+}
+
+function sanitizeForPg<T>(value: T): T {
+	if (typeof value === 'string') return stripUnsafeChars(value) as unknown as T;
+	if (value === null || typeof value !== 'object') return value;
+	if (Array.isArray(value)) return value.map((v) => sanitizeForPg(v)) as unknown as T;
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+		out[k] = sanitizeForPg(v);
+	}
+	return out as unknown as T;
+}
+
 export class IngestionService {
 	private static auditService = new AuditService();
 
@@ -1368,6 +1390,20 @@ export class IngestionService {
 			// Read the raw bytes from the temp file written by the connector
 			const rawEmlBuffer = await readFile(email.tempFilePath);
 
+			// Strip Postgres-unsafe chars (NUL, unpaired surrogates) from text
+			// fields. Without this, certain malformed source emails abort the
+			// archived_emails INSERT with error code 22021 and the worker
+			// retry loop blocks the entire mailbox sync.
+			email.subject = email.subject ? stripUnsafeChars(email.subject) : email.subject;
+			email.path = email.path ? stripUnsafeChars(email.path) : email.path;
+			if (Array.isArray(email.tags)) email.tags = email.tags.map(stripUnsafeChars);
+			email.from = sanitizeForPg(email.from);
+			email.to = sanitizeForPg(email.to);
+			email.cc = sanitizeForPg(email.cc);
+			email.bcc = sanitizeForPg(email.bcc);
+			email.threadId = email.threadId ? stripUnsafeChars(email.threadId) : email.threadId;
+			email.id = email.id ? stripUnsafeChars(email.id) : email.id;
+
 			// If this source is a child in a merge group, redirect all storage and DB
 			// ownership to the root source. Child sources are "assistants" — they fetch
 			// emails on behalf of the root but never own any stored content.
@@ -1387,7 +1423,11 @@ export class IngestionService {
 			// agree on them (#440). The provider id needs it as much as the header does: for IMAP
 			// and the file-based connectors email.id IS the parsed Message-ID, and it lands in a
 			// btree of its own via provider_msg_source_idx.
-			messageId = IngestionService.boundMessageKey(messageId);
+			// messageId is sanitized here rather than above because it is derived after that
+			// point — from the header, or from a generated fallback. Sanitizing before bounding
+			// keeps the hash in the over-long branch taken over the value actually stored, so a
+			// NUL can never reach either btree. email.id was already sanitized above.
+			messageId = IngestionService.boundMessageKey(stripUnsafeChars(messageId));
 			const providerMessageId = IngestionService.boundMessageKey(email.id);
 			// ── Three-gate deduplication ──────────────────────────────────────
 			// Gate 1: Per-mailbox idempotency — has THIS mailbox already archived


### PR DESCRIPTION
Fixes a sync stall: Postgres rejects U+0000 and unpaired UTF-16 surrogates in `TEXT` columns (error 22021). One malformed message aborts the insert, the worker retries, the retry hits the same row — and that mailbox never finishes syncing.

Strips NULs and replaces lone surrogates with U+FFFD across the text fields that go into the `archived_emails` insert.

Sanitizing happens **before** `boundMessageKey`, so in the over-long branch the sha256 is taken over the value actually stored and a NUL can never reach either btree.

**Scope:** 1 file, +41/−1. No schema change, no API change, no new dependency.

Hit and fixed while running the OSS image against a live archive (~214k emails, 5 sources).

**Verification:** no test runner exists in the repo yet, so this was exercised by ingesting a live archive rather than by a unit test. I have opened a separate PR adding a test runner and PR CI; if that lands I am happy to add a case for this sanitizer.
