### PR TITLE
feat(search): remember the preferred matching strategy (closes #247)

### DIFF
--- a/packages/frontend/src/lib/translations/bg.json
+++ b/packages/frontend/src/lib/translations/bg.json
@@ -76,6 +76,8 @@
 			"strategy_verbatim": "Дословно",
 			"strategy_frequency": "Честота",
 			"select_strategy": "Изберете стратегия",
+			"set_default_strategy": "Задай по подразбиране",
+			"clear_default_strategy": "Изчисти по подразбиране",
 			"error": "Грешка",
 			"found_results_in": "Намерени {{total}} резултати за {{seconds}}и",
 			"found_results": "Намерени {{total}} резултати",

--- a/packages/frontend/src/lib/translations/de.json
+++ b/packages/frontend/src/lib/translations/de.json
@@ -112,6 +112,8 @@
 			"strategy_verbatim": "Wörtlich",
 			"strategy_frequency": "Frequenz",
 			"select_strategy": "Wählen Sie eine Strategie",
+			"set_default_strategy": "Als Standard festlegen",
+			"clear_default_strategy": "Standard entfernen",
 			"error": "Fehler",
 			"found_results_in": "{{total}} Ergebnisse in {{seconds}}s gefunden",
 			"found_results": "{{total}} Ergebnisse gefunden",

--- a/packages/frontend/src/lib/translations/el.json
+++ b/packages/frontend/src/lib/translations/el.json
@@ -76,6 +76,8 @@
 			"strategy_verbatim": "Κατά λέξη",
 			"strategy_frequency": "Συχνότητα",
 			"select_strategy": "Επιλέξτε μια στρατηγική",
+			"set_default_strategy": "Ορισμός ως προεπιλογή",
+			"clear_default_strategy": "Κατάργηση προεπιλογής",
 			"error": "Σφάλμα",
 			"found_results_in": "Βρέθηκαν {{total}} αποτελέσματα σε {{seconds}}s",
 			"found_results": "Βρέθηκαν {{total}} αποτελέσματα",

--- a/packages/frontend/src/lib/translations/en.json
+++ b/packages/frontend/src/lib/translations/en.json
@@ -190,6 +190,8 @@
 			"strategy_verbatim": "Verbatim",
 			"strategy_frequency": "Frequency",
 			"select_strategy": "Select a strategy",
+			"set_default_strategy": "Set as default",
+			"clear_default_strategy": "Clear default",
 			"error": "Error",
 			"found_results_in": "Found {{total}} results in {{seconds}}s",
 			"found_results": "Found {{total}} results",

--- a/packages/frontend/src/lib/translations/es.json
+++ b/packages/frontend/src/lib/translations/es.json
@@ -112,6 +112,8 @@
 			"strategy_verbatim": "Literal",
 			"strategy_frequency": "Frecuencia",
 			"select_strategy": "Seleccione una estrategia",
+			"set_default_strategy": "Establecer como predeterminado",
+			"clear_default_strategy": "Borrar predeterminado",
 			"error": "Error",
 			"found_results_in": "Se encontraron {{total}} resultados en {{seconds}}s",
 			"found_results": "Se encontraron {{total}} resultados",

--- a/packages/frontend/src/lib/translations/et.json
+++ b/packages/frontend/src/lib/translations/et.json
@@ -76,6 +76,8 @@
 			"strategy_verbatim": "Sõnasõnaline",
 			"strategy_frequency": "Sagedus",
 			"select_strategy": "Valige strateegia",
+			"set_default_strategy": "Määra vaikeväärtuseks",
+			"clear_default_strategy": "Eemalda vaikeväärtus",
 			"error": "Viga",
 			"found_results_in": "Leiti {{total}} tulemust {{seconds}} sekundiga",
 			"found_results": "Leiti {{total}} tulemust",

--- a/packages/frontend/src/lib/translations/fr.json
+++ b/packages/frontend/src/lib/translations/fr.json
@@ -112,6 +112,8 @@
 			"strategy_verbatim": "Textuelle",
 			"strategy_frequency": "Fréquence",
 			"select_strategy": "Sélectionnez une stratégie",
+			"set_default_strategy": "Définir par défaut",
+			"clear_default_strategy": "Effacer la valeur par défaut",
 			"error": "Erreur",
 			"found_results_in": "{{total}} résultats trouvés en {{seconds}}s",
 			"found_results": "{{total}} résultats trouvés",

--- a/packages/frontend/src/lib/translations/it.json
+++ b/packages/frontend/src/lib/translations/it.json
@@ -84,6 +84,8 @@
 			"strategy_verbatim": "Testuale",
 			"strategy_frequency": "Frequenza",
 			"select_strategy": "Seleziona una strategia",
+			"set_default_strategy": "Imposta come predefinito",
+			"clear_default_strategy": "Rimuovi predefinito",
 			"error": "Errore",
 			"found_results_in": "Trovati {{total}} risultati in {{seconds}}s",
 			"found_results": "Trovati {{total}} risultati",

--- a/packages/frontend/src/lib/translations/ja.json
+++ b/packages/frontend/src/lib/translations/ja.json
@@ -76,6 +76,8 @@
 			"strategy_verbatim": "逐語的",
 			"strategy_frequency": "頻度",
 			"select_strategy": "戦略を選択",
+			"set_default_strategy": "デフォルトに設定",
+			"clear_default_strategy": "デフォルトを解除",
 			"error": "エラー",
 			"found_results_in": "{{seconds}}秒で{{total}}件の結果が見つかりました",
 			"found_results": "{{total}}件の結果が見つかりました",

--- a/packages/frontend/src/lib/translations/nl.json
+++ b/packages/frontend/src/lib/translations/nl.json
@@ -76,6 +76,8 @@
 			"strategy_verbatim": "Letterlijk",
 			"strategy_frequency": "Frequentie",
 			"select_strategy": "Selecteer een strategie",
+			"set_default_strategy": "Als standaard instellen",
+			"clear_default_strategy": "Standaard wissen",
 			"error": "Fout",
 			"found_results_in": "{{total}} resultaten gevonden in {{seconds}}s",
 			"found_results": "{{total}} resultaten gevonden",

--- a/packages/frontend/src/lib/translations/pt.json
+++ b/packages/frontend/src/lib/translations/pt.json
@@ -76,6 +76,8 @@
 			"strategy_verbatim": "Verbatim",
 			"strategy_frequency": "Frequência",
 			"select_strategy": "Selecione uma estratégia",
+			"set_default_strategy": "Definir como padrão",
+			"clear_default_strategy": "Limpar padrão",
 			"error": "Erro",
 			"found_results_in": "Encontrados {{total}} resultados em {{seconds}}s",
 			"found_results": "Encontrados {{total}} resultados",

--- a/packages/frontend/src/routes/dashboard/search/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/search/+page.svelte
@@ -23,6 +23,11 @@
 	import Paperclip from 'lucide-svelte/icons/paperclip';
 	import AdvancedSearchPanel from '$lib/components/search/AdvancedSearchPanel.svelte';
 	import EmptyStateIcon from '$lib/components/custom/EmptyStateIcon.svelte';
+	import {
+		readStrategyPreference,
+		writeStrategyPreference,
+		clearStrategyPreference,
+	} from './strategy-preference';
 	import Search from 'lucide-svelte/icons/search';
 	import SearchX from 'lucide-svelte/icons/search-x';
 
@@ -97,9 +102,39 @@
 	);
 
 	let isMounted = $state(false);
+	// Mirrors the stored preference so the save/clear affordance re-renders when it changes.
+	let savedStrategy = $state<MatchingStrategy | undefined>(undefined);
+
 	onMount(() => {
 		isMounted = true;
+		savedStrategy = readStrategyPreference();
+
+		// An explicit ?matchingStrategy= in the URL always wins — a shared or
+		// bookmarked search must reproduce itself regardless of local preference.
+		// Only when the URL is silent does the saved default apply, and then the
+		// URL is rewritten so a submit or pagination carries it forward.
+		if (!savedStrategy) return;
+		if (urlHasStrategy()) return;
+		if (savedStrategy === matchingStrategy) return;
+		matchingStrategy = savedStrategy;
+		goto(buildPageUrl(page), { replaceState: true, keepFocus: true, noScroll: true });
 	});
+
+	function urlHasStrategy(): boolean {
+		return new URL(window.location.href).searchParams.has('matchingStrategy');
+	}
+
+	const strategyIsSaved = $derived(savedStrategy === matchingStrategy);
+
+	function saveStrategyDefault() {
+		writeStrategyPreference(matchingStrategy);
+		savedStrategy = matchingStrategy;
+	}
+
+	function clearStrategyDefault() {
+		clearStrategyPreference();
+		savedStrategy = undefined;
+	}
 
 	// Escape all HTML, then restore only Meilisearch's <em> highlight tags. Prevents
 	// XSS from attacker-controlled field content (subjects, addresses, attachment names)
@@ -260,6 +295,19 @@
 							{/each}
 						</Select.Content>
 					</Select.Root>
+					<!-- #247: one click to make the current strategy the default for
+					     this browser, so users who always want Verbatim stop re-picking it. -->
+					{#if isMounted}
+						<button
+							type="button"
+							class="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline-offset-2 hover:underline"
+							onclick={strategyIsSaved ? clearStrategyDefault : saveStrategyDefault}
+						>
+							{strategyIsSaved
+								? $t('app.search.clear_default_strategy')
+								: $t('app.search.set_default_strategy')}
+						</button>
+					{/if}
 				</div>
 				<AdvancedSearchPanel
 					availableSources={data.ingestionSources}

--- a/packages/frontend/src/routes/dashboard/search/strategy-preference.ts
+++ b/packages/frontend/src/routes/dashboard/search/strategy-preference.ts
@@ -1,0 +1,50 @@
+import type { MatchingStrategy } from '@open-archiver/types';
+
+/**
+ * Remembers the user's preferred matching strategy (#247).
+ *
+ * Kept in localStorage rather than on the user record: the strategy is a
+ * per-browser habit rather than account state, and storing it client-side keeps
+ * this to a frontend-only change with no schema or API surface.
+ */
+const KEY = 'openarchiver.search.matchingStrategy';
+
+const VALID: readonly MatchingStrategy[] = ['last', 'all', 'frequency'];
+
+const isValid = (value: string | null): value is MatchingStrategy =>
+	value !== null && (VALID as readonly string[]).includes(value);
+
+/**
+ * The saved strategy, or undefined when nothing is saved or the stored value is
+ * no longer one this build understands. Safe to call during SSR — returns
+ * undefined when there is no window.
+ */
+export function readStrategyPreference(): MatchingStrategy | undefined {
+	if (typeof localStorage === 'undefined') return undefined;
+	try {
+		const stored = localStorage.getItem(KEY);
+		return isValid(stored) ? stored : undefined;
+	} catch {
+		// Private-mode and storage-disabled browsers throw on access rather than
+		// returning null. A missing preference is not an error worth surfacing.
+		return undefined;
+	}
+}
+
+export function writeStrategyPreference(strategy: MatchingStrategy): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(KEY, strategy);
+	} catch {
+		// Nothing actionable — the preference simply will not persist.
+	}
+}
+
+export function clearStrategyPreference(): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.removeItem(KEY);
+	} catch {
+		// As above.
+	}
+}


### PR DESCRIPTION
Closes #247.

The issue describes switching to Verbatim on every search because Fuzzy returns too much on 80k emails. This adds a **Set as default** control beside the strategy selector; clicking again clears it.

**Precedence:** an explicit `?matchingStrategy=` always wins, so a shared or bookmarked search still reproduces itself. The saved default only applies when the URL is silent, and the URL is then rewritten so submit and pagination carry it forward.

localStorage rather than the user record — this is a per-browser habit, so no schema or API change. Storage access is wrapped because private-mode browsers throw on access rather than returning null.

![set as default](https://raw.githubusercontent.com/kisst/OpenArchiver/pr-screenshots/shots/pr3-after.jpg)

**Scope:** 13 files, +120. Written against the current search page rather than ported; the existing `matchingStrategy` plumbing is reused. Both new i18n keys across all 11 locales.

**Verification:** driven in a browser; `tsc`, `svelte-check` and Prettier clean.
