### PR TITLE
feat(frontend): user-selectable date format

### DIFF
--- a/packages/frontend/src/lib/components/custom/EmailThread.svelte
+++ b/packages/frontend/src/lib/components/custom/EmailThread.svelte
@@ -3,6 +3,7 @@
 	import type { ArchivedEmail } from '@open-archiver/types';
 	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
 	import { t } from '$lib/translations';
+	import { formatDateTimeStore } from '$lib/stores/dateFormat.store';
 
 	let {
 		thread,
@@ -61,7 +62,7 @@
 								>{$t('app.archive.from')}: {item.senderName ||
 									item.senderEmail}</span
 							>
-							<time class="">{new Date(item.sentAt).toLocaleString()}</time>
+							<time class="">{$formatDateTimeStore(item.sentAt)}</time>
 						</div>
 					</div>
 				{/each}

--- a/packages/frontend/src/lib/stores/dateFormat.store.ts
+++ b/packages/frontend/src/lib/stores/dateFormat.store.ts
@@ -1,0 +1,57 @@
+import { persisted } from 'svelte-persisted-store';
+import { derived, type Readable } from 'svelte/store';
+
+export type DateFormat = 'locale' | 'iso' | 'eu' | 'us';
+
+/** Anything the dashboard passes to a date formatter. */
+export type DateInput = Date | string | number | null | undefined;
+
+/** A formatter bound to the user's current preference. */
+export type DateFormatter = (value: DateInput) => string;
+
+export const dateFormat = persisted<DateFormat>('dateFormat', 'locale');
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+function toDate(value: DateInput): Date | null {
+	if (value === null || value === undefined || value === '') return null;
+	const d = value instanceof Date ? value : new Date(value);
+	return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function formatDate(value: DateInput, format: DateFormat = 'locale'): string {
+	const d = toDate(value);
+	if (!d) return '';
+	const y = d.getFullYear();
+	const m = pad(d.getMonth() + 1);
+	const day = pad(d.getDate());
+	switch (format) {
+		case 'iso':
+			return `${y}-${m}-${day}`;
+		case 'eu':
+			return `${day}/${m}/${y}`;
+		case 'us':
+			return `${m}/${day}/${y}`;
+		case 'locale':
+		default:
+			return d.toLocaleDateString();
+	}
+}
+
+export function formatDateTime(value: DateInput, format: DateFormat = 'locale'): string {
+	const d = toDate(value);
+	if (!d) return '';
+	if (format === 'locale') return d.toLocaleString();
+	const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+	return `${formatDate(d, format)} ${time}`;
+}
+
+export const formatDateStore: Readable<DateFormatter> = derived(
+	dateFormat,
+	($f) => (value: DateInput) => formatDate(value, $f)
+);
+
+export const formatDateTimeStore: Readable<DateFormatter> = derived(
+	dateFormat,
+	($f) => (value: DateInput) => formatDateTime(value, $f)
+);

--- a/packages/frontend/src/lib/translations/de.json
+++ b/packages/frontend/src/lib/translations/de.json
@@ -161,7 +161,15 @@
 			"new_password": "Neues Passwort",
 			"confirm_new_password": "Neues Passwort bestätigen",
 			"operation_successful": "Vorgang erfolgreich",
-			"passwords_do_not_match": "Passwörter stimmen nicht überein"
+			"passwords_do_not_match": "Passwörter stimmen nicht überein",
+			"preferences": "Einstellungen",
+			"preferences_desc": "Passen Sie an, wie Informationen für Sie angezeigt werden.",
+			"date_format": "Datumsformat",
+			"date_format_desc": "Wählen Sie, wie Datum und Uhrzeit in der App angezeigt werden.",
+			"date_format_locale": "Browser-Sprache (Standard)",
+			"date_format_iso": "ISO 8601 (JJJJ-MM-TT)",
+			"date_format_eu": "Europäisch (TT.MM.JJJJ)",
+			"date_format_us": "USA (MM/TT/JJJJ)"
 		},
 		"system_settings": {
 			"title": "Systemeinstellungen",

--- a/packages/frontend/src/lib/translations/en.json
+++ b/packages/frontend/src/lib/translations/en.json
@@ -279,7 +279,15 @@
 			"new_password": "New Password",
 			"confirm_new_password": "Confirm New Password",
 			"operation_successful": "Operation successful",
-			"passwords_do_not_match": "Passwords do not match"
+			"passwords_do_not_match": "Passwords do not match",
+			"preferences": "Preferences",
+			"preferences_desc": "Customize how information is displayed for you.",
+			"date_format": "Date format",
+			"date_format_desc": "Choose how dates and times are shown across the app.",
+			"date_format_locale": "Browser locale (default)",
+			"date_format_iso": "ISO 8601 (YYYY-MM-DD)",
+			"date_format_eu": "European (DD/MM/YYYY)",
+			"date_format_us": "US (MM/DD/YYYY)"
 		},
 		"system_settings": {
 			"title": "System Settings",

--- a/packages/frontend/src/lib/translations/es.json
+++ b/packages/frontend/src/lib/translations/es.json
@@ -161,7 +161,15 @@
 			"new_password": "Nueva contraseña",
 			"confirm_new_password": "Confirmar nueva contraseña",
 			"operation_successful": "Operación exitosa",
-			"passwords_do_not_match": "Las contraseñas no coinciden"
+			"passwords_do_not_match": "Las contraseñas no coinciden",
+			"preferences": "Preferencias",
+			"preferences_desc": "Personaliza cómo se muestra la información.",
+			"date_format": "Formato de fecha",
+			"date_format_desc": "Elige cómo se muestran las fechas y horas en la aplicación.",
+			"date_format_locale": "Idioma del navegador (predeterminado)",
+			"date_format_iso": "ISO 8601 (AAAA-MM-DD)",
+			"date_format_eu": "Europeo (DD/MM/AAAA)",
+			"date_format_us": "EE. UU. (MM/DD/AAAA)"
 		},
 		"system_settings": {
 			"title": "Configuración del sistema",

--- a/packages/frontend/src/lib/translations/fr.json
+++ b/packages/frontend/src/lib/translations/fr.json
@@ -161,7 +161,15 @@
 			"new_password": "Nouveau mot de passe",
 			"confirm_new_password": "Confirmer le nouveau mot de passe",
 			"operation_successful": "Opération réussie",
-			"passwords_do_not_match": "Les mots de passe ne correspondent pas"
+			"passwords_do_not_match": "Les mots de passe ne correspondent pas",
+			"preferences": "Préférences",
+			"preferences_desc": "Personnalisez l'affichage des informations.",
+			"date_format": "Format de date",
+			"date_format_desc": "Choisissez l'affichage des dates et heures dans l'application.",
+			"date_format_locale": "Langue du navigateur (par défaut)",
+			"date_format_iso": "ISO 8601 (AAAA-MM-JJ)",
+			"date_format_eu": "Européen (JJ/MM/AAAA)",
+			"date_format_us": "États-Unis (MM/JJ/AAAA)"
 		},
 		"system_settings": {
 			"title": "Paramètres système",

--- a/packages/frontend/src/lib/translations/it.json
+++ b/packages/frontend/src/lib/translations/it.json
@@ -133,7 +133,15 @@
 			"new_password": "Nuova password",
 			"confirm_new_password": "Conferma nuova password",
 			"operation_successful": "Operazione riuscita",
-			"passwords_do_not_match": "Le password non corrispondono"
+			"passwords_do_not_match": "Le password non corrispondono",
+			"preferences": "Preferenze",
+			"preferences_desc": "Personalizza come vengono mostrate le informazioni.",
+			"date_format": "Formato data",
+			"date_format_desc": "Scegli come vengono mostrate date e ore nell'app.",
+			"date_format_locale": "Lingua del browser (predefinito)",
+			"date_format_iso": "ISO 8601 (AAAA-MM-GG)",
+			"date_format_eu": "Europeo (GG/MM/AAAA)",
+			"date_format_us": "USA (MM/GG/AAAA)"
 		},
 		"system_settings": {
 			"title": "Impostazioni di sistema",

--- a/packages/frontend/src/routes/dashboard/admin/jobs/[queueName]/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/admin/jobs/[queueName]/+page.svelte
@@ -11,6 +11,7 @@
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
+	import { formatDateTimeStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 	let queue = $derived(data.queue);
@@ -111,15 +112,15 @@
 									{job.state}
 								{/if}
 							</Table.Cell>
-							<Table.Cell>{new Date(job.timestamp).toLocaleString()}</Table.Cell>
+							<Table.Cell>{$formatDateTimeStore(job.timestamp)}</Table.Cell>
 							<Table.Cell
 								>{job.processedOn
-									? new Date(job.processedOn).toLocaleString()
+									? $formatDateTimeStore(job.processedOn)
 									: 'N/A'}</Table.Cell
 							>
 							<Table.Cell
 								>{job.finishedOn
-									? new Date(job.finishedOn).toLocaleString()
+									? $formatDateTimeStore(job.finishedOn)
 									: 'N/A'}</Table.Cell
 							>
 							<Table.Cell>

--- a/packages/frontend/src/routes/dashboard/archived-emails/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/archived-emails/+page.svelte
@@ -13,6 +13,7 @@
 	import { api } from '$lib/api.client';
 	import { setAlert } from '$lib/components/custom/alert/alert-state.svelte';
 	import type { PaginatedArchivedEmails } from '@open-archiver/types';
+	import { formatDateTimeStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 
@@ -163,7 +164,7 @@
 								}}
 							/>
 						</Table.Cell>
-						<Table.Cell>{new Date(email.sentAt).toLocaleString()}</Table.Cell>
+						<Table.Cell>{$formatDateTimeStore(email.sentAt)}</Table.Cell>
 
 						<Table.Cell>
 							<div class="max-w-100 truncate">

--- a/packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte
@@ -28,6 +28,7 @@
 	} from 'lucide-svelte';
 	import { page } from '$app/state';
 	import { enhance } from '$app/forms';
+	import { formatDateStore, formatDateTimeStore } from '$lib/stores/dateFormat.store';
 	import type { LegalHold, EmailLegalHoldInfo } from '@open-archiver/types';
 	import PostalMime, { type Attachment as PostalAttachment } from 'postal-mime';
 	import { Paperclip } from 'lucide-svelte';
@@ -291,9 +292,9 @@
 					<Card.Description>
 						{$t('app.archive.from')}: {email.senderName && email.senderEmail
 							? `${email.senderName} <${email.senderEmail}>`
-							: email.senderName || email.senderEmail} | {$t('app.archive.sent')}: {new Date(
+							: email.senderName || email.senderEmail} | {$t('app.archive.sent')}: {$formatDateTimeStore(
 							email.sentAt
-						).toLocaleString()}
+						)}
 					</Card.Description>
 				</Card.Header>
 				<Card.Content>
@@ -619,7 +620,7 @@
 											</div>
 											<p class="text-muted-foreground mt-0.5 text-xs">
 												{$t('app.archive_legal_holds.applied_at')}:
-												{new Date(holdInfo.appliedAt).toLocaleDateString()}
+												{$formatDateStore(holdInfo.appliedAt)}
 											</p>
 										</div>
 										<form
@@ -781,7 +782,7 @@
 												? 'destructive'
 												: 'secondary'}
 										>
-											{scheduledDeletionDate.toLocaleDateString()}
+											{$formatDateStore(scheduledDeletionDate)}
 										</Badge>
 									</div>
 								{/if}
@@ -926,7 +927,7 @@
 													? 'destructive'
 													: 'secondary'}
 											>
-												{scheduledDeletionDateByLabel.toLocaleDateString()}
+												{$formatDateStore(scheduledDeletionDateByLabel)}
 											</Badge>
 										</div>
 									{/if}

--- a/packages/frontend/src/routes/dashboard/compliance/audit-log/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/compliance/audit-log/+page.svelte
@@ -16,6 +16,7 @@
 	import * as Pagination from '$lib/components/ui/pagination/index.js';
 	import ChevronLeft from 'lucide-svelte/icons/chevron-left';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import { formatDateTimeStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 
@@ -127,7 +128,7 @@
 			{#if logs && logs.length > 0}
 				{#each logs as log (log.id)}
 					<Table.Row class="cursor-pointer" onclick={() => viewLogDetails(log)}>
-						<Table.Cell>{new Date(log.timestamp).toLocaleString()}</Table.Cell>
+						<Table.Cell>{$formatDateTimeStore(log.timestamp)}</Table.Cell>
 						<Table.Cell>
 							<span class="font-mono text-xs">{log.actorIdentifier}</span>
 						</Table.Cell>
@@ -248,7 +249,7 @@
 				<div class="grid grid-cols-4 items-center gap-4">
 					<Label class="text-right">{$t('app.audit_log.timestamp')}</Label>
 					<span class="col-span-3 font-mono text-sm"
-						>{new Date(selectedLog.timestamp).toLocaleString()}</span
+						>{$formatDateTimeStore(selectedLog.timestamp)}</span
 					>
 				</div>
 				<div class="grid grid-cols-4 items-center gap-4">

--- a/packages/frontend/src/routes/dashboard/compliance/legal-holds/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/compliance/legal-holds/+page.svelte
@@ -13,6 +13,7 @@
 	import { MoreHorizontal, Plus, ShieldCheck } from 'lucide-svelte';
 	import { setAlert } from '$lib/components/custom/alert/alert-state.svelte';
 	import type { LegalHold } from '@open-archiver/types';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData; form: ActionData } = $props();
 
@@ -149,7 +150,7 @@
 							{/if}
 						</Table.Cell>
 						<Table.Cell>
-							{new Date(hold.createdAt).toLocaleDateString()}
+							{$formatDateStore(hold.createdAt)}
 						</Table.Cell>
 						<Table.Cell class="text-right">
 							<DropdownMenu.Root>

--- a/packages/frontend/src/routes/dashboard/compliance/retention-labels/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/compliance/retention-labels/+page.svelte
@@ -14,6 +14,7 @@
 	import { MoreHorizontal, Plus } from 'lucide-svelte';
 	import { setAlert } from '$lib/components/custom/alert/alert-state.svelte';
 	import type { RetentionLabel } from '@open-archiver/types';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -109,7 +110,7 @@
 							{/if}
 						</Table.Cell>
 						<Table.Cell>
-							{new Date(label.createdAt).toLocaleDateString()}
+							{$formatDateStore(label.createdAt)}
 						</Table.Cell>
 						<Table.Cell class="text-right">
 							<DropdownMenu.Root>

--- a/packages/frontend/src/routes/dashboard/ingestions/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/ingestions/+page.svelte
@@ -21,6 +21,7 @@
 	import * as HoverCard from '$lib/components/ui/hover-card/index.js';
 	import { t } from '$lib/translations';
 	import { goto } from '$app/navigation';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 	let ingestionSources = $state(data.ingestionSources as SafeIngestionSource[]);
@@ -665,9 +666,7 @@
 									onCheckedChange={() => handleToggle(source)}
 								/>
 							</Table.Cell>
-							<Table.Cell
-								>{new Date(source.createdAt).toLocaleDateString()}</Table.Cell
-							>
+							<Table.Cell>{$formatDateStore(source.createdAt)}</Table.Cell>
 							<Table.Cell class="text-right">
 								<DropdownMenu.Root>
 									<DropdownMenu.Trigger>
@@ -788,11 +787,7 @@
 											onCheckedChange={() => handleToggle(child)}
 										/>
 									</Table.Cell>
-									<Table.Cell
-										>{new Date(
-											child.createdAt
-										).toLocaleDateString()}</Table.Cell
-									>
+									<Table.Cell>{$formatDateStore(child.createdAt)}</Table.Cell>
 									<Table.Cell class="text-right">
 										<DropdownMenu.Root>
 											<DropdownMenu.Trigger>

--- a/packages/frontend/src/routes/dashboard/ingestions/[id]/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/ingestions/[id]/+page.svelte
@@ -20,12 +20,14 @@
 		Database,
 	} from 'lucide-svelte';
 	import { t } from '$lib/translations';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 	let stats = $derived(data.stats);
 
-	const fmtDate = (d: string | null) =>
-		d ? new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '—';
+	// Routed through the store so this page honours the account date-format
+	// preference like the rest of the dashboard.
+	const fmtDate = (d: string | null) => (d ? $formatDateStore(d) : '—');
 
 	// Index coverage percentage, clamped to 100 (Meilisearch count can momentarily
 	// exceed the DB count).

--- a/packages/frontend/src/routes/dashboard/ingestions/journaling/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/ingestions/journaling/+page.svelte
@@ -12,6 +12,7 @@
 	import { setAlert } from '$lib/components/custom/alert/alert-state.svelte';
 	import JournalingSourceForm from '$lib/components/custom/JournalingSourceForm.svelte';
 	import type { JournalingSource } from '@open-archiver/types';
+	import { formatDateTimeStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData; form: ActionData } = $props();
 
@@ -222,7 +223,7 @@
 						</Table.Cell>
 						<Table.Cell>
 							{#if source.lastReceivedAt}
-								{new Date(source.lastReceivedAt).toLocaleString()}
+								{$formatDateTimeStore(source.lastReceivedAt)}
 							{:else}
 								<span class="text-muted-foreground text-xs italic">
 									{$t('app.journaling.never')}

--- a/packages/frontend/src/routes/dashboard/search/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/search/+page.svelte
@@ -25,6 +25,7 @@
 	import EmptyStateIcon from '$lib/components/custom/EmptyStateIcon.svelte';
 	import Search from 'lucide-svelte/icons/search';
 	import SearchX from 'lucide-svelte/icons/search-x';
+	import { formatDateTimeStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 	let searchResult = $derived(data.searchResult);

--- a/packages/frontend/src/routes/dashboard/settings/account/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/account/+page.svelte
@@ -13,6 +13,20 @@
 	import { ShieldCheck, ShieldOff, Copy, RefreshCw } from 'lucide-svelte';
 	import { format } from 'date-fns';
 	import type { MfaSetupResponse, MfaEnrollResponse } from '@open-archiver/types';
+	import * as Select from '$lib/components/ui/select';
+	import { dateFormat, formatDateTime, type DateFormat } from '$lib/stores/dateFormat.store';
+
+	const dateFormatOptions: { value: DateFormat; key: string }[] = [
+		{ value: 'locale', key: 'app.account.date_format_locale' },
+		{ value: 'iso', key: 'app.account.date_format_iso' },
+		{ value: 'eu', key: 'app.account.date_format_eu' },
+		{ value: 'us', key: 'app.account.date_format_us' },
+	];
+	const dateFormatLabel = $derived(
+		dateFormatOptions.find((o) => o.value === $dateFormat)?.key ??
+			'app.account.date_format_locale'
+	);
+	const dateFormatPreview = $derived(formatDateTime(new Date(), $dateFormat));
 
 	let { data, form } = $props();
 	let user = $derived(data.user);
@@ -292,6 +306,42 @@
 		</Card.Footer>
 	</Card.Root>
 
+	<!-- Preferences -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>{$t('app.account.preferences')}</Card.Title>
+			<Card.Description>{$t('app.account.preferences_desc')}</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
+				<div>
+					<Label for="date_format">{$t('app.account.date_format')}</Label>
+					<p class="text-muted-foreground text-sm">
+						{$t('app.account.date_format_desc')}
+					</p>
+					<p class="text-muted-foreground mt-1 text-xs">
+						{dateFormatPreview}
+					</p>
+				</div>
+				<Select.Root
+					type="single"
+					value={$dateFormat}
+					onValueChange={(v) => {
+						if (v) $dateFormat = v as DateFormat;
+					}}
+				>
+					<Select.Trigger id="date_format" class="w-full sm:w-[260px]">
+						{$t(dateFormatLabel)}
+					</Select.Trigger>
+					<Select.Content>
+						{#each dateFormatOptions as option (option.value)}
+							<Select.Item value={option.value}>{$t(option.key)}</Select.Item>
+						{/each}
+					</Select.Content>
+				</Select.Root>
+			</div>
+		</Card.Content>
+	</Card.Root>
 	<!-- Two-Factor Authentication (enterprise only) -->
 	{#if data.mfaStatus !== null}
 		<Card.Root>

--- a/packages/frontend/src/routes/dashboard/settings/api-keys/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/api-keys/+page.svelte
@@ -12,6 +12,7 @@
 	import { setAlert } from '$lib/components/custom/alert/alert-state.svelte';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { api } from '$lib/api.client';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	// Temporary type definition based on the backend schema
 	type ApiKey = {
@@ -196,12 +197,8 @@
 						<Table.Row>
 							<Table.Cell>{apiKey.name}</Table.Cell>
 							<Table.Cell>{apiKey.key.substring(0, 8)}</Table.Cell>
-							<Table.Cell
-								>{new Date(apiKey.expiresAt).toLocaleDateString()}</Table.Cell
-							>
-							<Table.Cell
-								>{new Date(apiKey.createdAt).toLocaleDateString()}</Table.Cell
-							>
+							<Table.Cell>{$formatDateStore(apiKey.expiresAt)}</Table.Cell>
+							<Table.Cell>{$formatDateStore(apiKey.createdAt)}</Table.Cell>
 							<Table.Cell class="text-right">
 								<DropdownMenu.Root>
 									<DropdownMenu.Trigger>

--- a/packages/frontend/src/routes/dashboard/settings/roles/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/roles/+page.svelte
@@ -10,6 +10,7 @@
 	import { api } from '$lib/api.client';
 	import type { Role } from '@open-archiver/types';
 	import { t } from '$lib/translations';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 	let roles = $state(data.roles);
@@ -132,7 +133,7 @@
 					{#each roles as role (role.id)}
 						<Table.Row>
 							<Table.Cell>{role.name}</Table.Cell>
-							<Table.Cell>{new Date(role.createdAt).toLocaleDateString()}</Table.Cell>
+							<Table.Cell>{$formatDateStore(role.createdAt)}</Table.Cell>
 							<Table.Cell class="text-right">
 								<DropdownMenu.Root>
 									<DropdownMenu.Trigger>

--- a/packages/frontend/src/routes/dashboard/settings/users/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/users/+page.svelte
@@ -10,6 +10,7 @@
 	import { api } from '$lib/api.client';
 	import type { User } from '@open-archiver/types';
 	import { t } from '$lib/translations';
+	import { formatDateStore } from '$lib/stores/dateFormat.store';
 
 	let { data }: { data: PageData } = $props();
 	let users = $state(data.users);
@@ -178,7 +179,7 @@
 							<Table.Cell>{user.first_name} {user.last_name}</Table.Cell>
 							<Table.Cell>{user.email}</Table.Cell>
 							<Table.Cell>{user.role?.name || 'N/A'}</Table.Cell>
-							<Table.Cell>{new Date(user.createdAt).toLocaleDateString()}</Table.Cell>
+							<Table.Cell>{$formatDateStore(user.createdAt)}</Table.Cell>
 							<Table.Cell class="text-right">
 								<DropdownMenu.Root>
 									<DropdownMenu.Trigger>


### PR DESCRIPTION
Adds a date-format preference in account settings — browser locale (default), ISO 8601, European, or US — applied across the dashboard through a persisted store, with a live preview beside the selector.

Uses `svelte-persisted-store`, already a dependency. Frontend only: no schema, no API, no new package.

Also routes the per-source statistics page through the store; it formatted its own dates with a fixed `toLocaleDateString` and so ignored the preference the rest of the dashboard respects.

![preferences card](https://raw.githubusercontent.com/kisst/OpenArchiver/pr-screenshots/shots/pr6-after.jpg)

**i18n:** added to the four locales that carry an `account` section (de, fr, es, it). The other six have no such section and already fall back to English for that whole page — creating one is a larger change than this PR.

**Scope:** 21 files, +190/−38. Independent of my other open PRs and mergeable in any order; it touches `translations/en.json`, so whichever merges second may need a one-line additive resolution.

**Verification:** driven in a browser; `svelte-check` and Prettier clean.
