### PR TITLE
ci: add PR checks and a test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+# Runs on pull requests, which currently have no build or test gate: the CLA bot
+# is the only check a PR gets today, so a change that fails to compile can be
+# merged without anything objecting.
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+jobs:
+    check:
+        name: Types, format, tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 10.13.1
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+
+            - name: Install
+              run: pnpm install --frozen-lockfile
+
+            - name: Build shared types
+              run: pnpm --filter @open-archiver/types build
+
+            - name: Typecheck backend
+              run: pnpm --filter @open-archiver/backend exec tsc --noEmit
+
+            - name: Typecheck frontend
+              run: pnpm --filter @open-archiver/frontend exec svelte-check --tsconfig ./tsconfig.json --threshold error
+
+            - name: Tests
+              run: pnpm test
+
+            - name: Formatting
+              # Scoped to the files the PR touches. A whole-tree `pnpm lint` fails on
+              # main today (drizzle snapshots and docs/api/openapi.json are generated
+              # and not prettier-formatted), so it cannot gate a PR until those are
+              # either formatted or ignored.
+              run: |
+                  git fetch origin "${{ github.base_ref || 'main' }}" --depth=1
+                  CHANGED=$(git diff --name-only --diff-filter=d \
+                    "origin/${{ github.base_ref || 'main' }}...HEAD" \
+                    | grep -E '\.(ts|js|svelte|json|md)$' \
+                    | grep -vE 'migrations/meta/|docs/api/openapi\.json' || true)
+                  if [ -z "$CHANGED" ]; then
+                    echo "No formattable files changed."
+                    exit 0
+                  fi
+                  echo "$CHANGED"
+                  echo "$CHANGED" | xargs ./node_modules/.bin/prettier --check
+
+    build:
+        name: Docker image
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: docker/setup-buildx-action@v3
+            - name: Build (no push)
+              # Same context and Dockerfile as the release workflow, amd64 only and
+              # never pushed — so a PR that breaks the image build says so before merge.
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: ./apps/open-archiver/Dockerfile
+                  platforms: linux/amd64
+                  push: false
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"docs:build": "pnpm docs:gen-spec && vitepress build docs",
 		"docs:preview": "vitepress preview docs",
 		"format": "prettier --write .",
-		"lint": "prettier --check ."
+		"lint": "prettier --check .",
+		"test": "pnpm --filter \"@open-archiver/backend\" test"
 	},
 	"dependencies": {
 		"concurrently": "^9.2.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,9 @@
 		"db:generate": "drizzle-kit generate --config=drizzle.config.ts",
 		"db:push": "drizzle-kit push --config=drizzle.config.ts",
 		"db:migrate": "node dist/database/migrate.js",
-		"db:migrate:dev": "ts-node-dev src/database/migrate.ts"
+		"db:migrate:dev": "ts-node-dev src/database/migrate.ts",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.844.0",
@@ -86,6 +88,7 @@
 		"swagger-jsdoc": "^6.2.8",
 		"ts-node-dev": "^2.0.0",
 		"tsconfig-paths": "^4.2.0",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"vitest": "^3.2.4"
 	}
 }

--- a/packages/backend/src/helpers/emailAddress.test.ts
+++ b/packages/backend/src/helpers/emailAddress.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { findByEmailKey, normalizeEmailAddress } from './emailAddress';
+
+describe('normalizeEmailAddress', () => {
+	it('lowercases and trims', () => {
+		expect(normalizeEmailAddress('  Alice@Example.COM ')).toBe('alice@example.com');
+	});
+
+	it('is idempotent', () => {
+		const once = normalizeEmailAddress(' Bob@Acme.io ');
+		expect(normalizeEmailAddress(once)).toBe(once);
+	});
+
+	it('makes two casings of one mailbox compare equal', () => {
+		// The property the archive depends on: search (case-insensitive) and
+		// permission checks (===) must agree on whether two addresses are the
+		// same mailbox.
+		expect(normalizeEmailAddress('Legal@Acme.com')).toBe(normalizeEmailAddress('legal@acme.com'));
+	});
+});
+
+describe('findByEmailKey', () => {
+	it('returns undefined for a missing bag', () => {
+		expect(findByEmailKey(undefined, 'a@b.com')).toBeUndefined();
+	});
+
+	it('finds an exact key', () => {
+		expect(findByEmailKey({ 'a@b.com': 'token' }, 'a@b.com')).toBe('token');
+	});
+
+	it('finds a key written before addresses were normalized', () => {
+		// Providers report mailboxes in whatever casing they were created with, so
+		// sync state can hold a mixed-case key from an earlier release.
+		expect(findByEmailKey({ 'User@Contoso.COM': 'delta-1' }, 'user@contoso.com')).toBe('delta-1');
+	});
+
+	it('looks up a mixed-case address against a normalized key', () => {
+		expect(findByEmailKey({ 'user@contoso.com': 'delta-2' }, 'User@Contoso.COM')).toBe('delta-2');
+	});
+
+	it('prefers the exact hit over a stale mixed-case entry', () => {
+		// Both keys can coexist for one sync cycle; the normalized one must win so
+		// the stale token does not resurrect.
+		const bag = { 'user@contoso.com': 'fresh', 'User@Contoso.COM': 'stale' };
+		expect(findByEmailKey(bag, 'user@contoso.com')).toBe('fresh');
+	});
+
+	it('returns undefined when nothing matches', () => {
+		expect(findByEmailKey({ 'a@b.com': 1 }, 'c@d.com')).toBeUndefined();
+	});
+
+	it('does not treat a falsy stored value as a miss', () => {
+		expect(findByEmailKey({ 'a@b.com': 0 }, 'A@B.com')).toBe(0);
+	});
+});

--- a/packages/backend/src/helpers/truncateToBytes.test.ts
+++ b/packages/backend/src/helpers/truncateToBytes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { truncateToBytes } from './truncateToBytes';
+
+describe('truncateToBytes', () => {
+	it('returns the input unchanged when it already fits', () => {
+		expect(truncateToBytes('hello', 100)).toBe('hello');
+	});
+
+	it('returns an empty string for a non-positive budget', () => {
+		expect(truncateToBytes('hello', 0)).toBe('');
+		expect(truncateToBytes('hello', -1)).toBe('');
+	});
+
+	it('truncates ASCII to exactly the byte budget', () => {
+		expect(truncateToBytes('abcdefghij', 4)).toBe('abcd');
+	});
+
+	it('never emits an unpaired surrogate when cutting inside an astral character', () => {
+		// '😀' is 4 UTF-8 bytes. Every budget from 1..3 must drop it whole rather
+		// than leave half a surrogate pair behind — the failure this helper exists
+		// to prevent, because JSON.stringify escapes the lone half and Meilisearch
+		// then rejects the entire request.
+		for (const budget of [1, 2, 3]) {
+			const out = truncateToBytes('😀', budget);
+			expect(out).toBe('');
+			expect(JSON.stringify(out)).not.toMatch(/\\ud[89ab][0-9a-f]{2}/i);
+		}
+		expect(truncateToBytes('😀', 4)).toBe('😀');
+	});
+
+	it('backs off to a character boundary for multi-byte text', () => {
+		// 'é' is 2 bytes: a 3-byte budget keeps one 'é' and drops the partial second.
+		expect(truncateToBytes('éé', 3)).toBe('é');
+		expect(truncateToBytes('éé', 4)).toBe('éé');
+	});
+
+	it('keeps the result within the byte budget for mixed scripts', () => {
+		const text = 'aä中😀b'.repeat(20);
+		for (const budget of [5, 17, 64, 233]) {
+			const out = truncateToBytes(text, budget);
+			expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(budget);
+			// Round-tripping is lossless only if no character was split.
+			expect(Buffer.from(out, 'utf8').toString('utf8')).toBe(out);
+		}
+	});
+
+	it('handles an empty string', () => {
+		expect(truncateToBytes('', 10)).toBe('');
+	});
+});

--- a/packages/backend/test/setup.ts
+++ b/packages/backend/test/setup.ts
@@ -1,0 +1,22 @@
+/**
+ * Vitest global setup. Populates the env vars that the production config
+ * modules (`src/config/storage.ts`, `src/database/index.ts`, etc.) demand at
+ * import time. Test code that needs different values can still override these
+ * via `vi.stubEnv` inside the test body.
+ *
+ * These are stub values — the test harness must never reach a real DB,
+ * Meilisearch, or S3.
+ */
+process.env.STORAGE_TYPE = process.env.STORAGE_TYPE ?? 'local';
+process.env.STORAGE_LOCAL_ROOT_PATH =
+	process.env.STORAGE_LOCAL_ROOT_PATH ?? '/tmp/open-archiver-test-storage';
+process.env.DATABASE_URL =
+	process.env.DATABASE_URL ?? 'postgresql://test:test@localhost:5432/test';
+process.env.REDIS_HOST = process.env.REDIS_HOST ?? 'localhost';
+process.env.REDIS_PORT = process.env.REDIS_PORT ?? '6379';
+process.env.MEILI_HOST = process.env.MEILI_HOST ?? 'http://localhost:7700';
+process.env.MEILI_MASTER_KEY = process.env.MEILI_MASTER_KEY ?? 'test-master-key';
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN ?? '1h';
+process.env.ENCRYPTION_KEY =
+	process.env.ENCRYPTION_KEY ?? '00000000000000000000000000000000';

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.ts'],
+		globals: false,
+		// Stub required env vars before test files load — config modules read
+		// these at import time and throw if missing. See test/setup.ts.
+		setupFiles: ['./test/setup.ts'],
+	},
+});


### PR DESCRIPTION
Pull requests currently have no build or test gate — the CLA bot is the only check a PR gets, so a change that fails to compile can be merged without anything objecting. I hit this while splitting a larger contribution: static checks passed on a branch whose UI was broken at runtime.

**Adds** a `CI` workflow running on pull requests:

- shared-types build, backend `tsc --noEmit`, frontend `svelte-check`
- `pnpm test` (vitest, added here)
- Prettier on changed files only
- a Docker image build, same Dockerfile as the release workflow, never pushed

**Plus a test runner and first tests:** vitest wired into the backend package with an env-stubbing setup file, and 17 cases covering two pure helpers that already exist on `main` — `truncateToBytes` (the astral-character truncation that would otherwise emit unpaired surrogates and make Meilisearch reject the whole request) and `emailAddress` (the normalization that keeps search and permission checks agreeing on what "the same mailbox" means).

Formatting is scoped to changed files deliberately: a whole-tree `pnpm lint` fails on `main` today, because the drizzle snapshots and `docs/api/openapi.json` are generated and not Prettier-formatted. Worth fixing, but it cannot gate a PR until it is.

**Scope:** ~10 files. No production code touched.

Opened separately from my feature PRs so adopting a test framework is its own decision rather than riding along inside a feature.
