### PR TITLE
fix(logging): serialize the error key so pino prints message and stack

### DIFF
--- a/apps/open-archiver/index.ts
+++ b/apps/open-archiver/index.ts
@@ -19,6 +19,6 @@ async function start() {
 }
 
 start().catch((error) => {
-	logger.error({ error }, 'Failed to start the server:', error);
+	logger.error({ err: error }, 'Failed to start the server');
 	process.exit(1);
 });

--- a/packages/backend/src/config/logger.ts
+++ b/packages/backend/src/config/logger.ts
@@ -3,6 +3,13 @@ import pino from 'pino';
 export const logger = pino({
 	level: process.env.LOG_LEVEL || 'info',
 	redact: ['password'],
+	// Pino only applies its error serializer to the `err` key. A lot of call sites log
+	// `{ error }` instead, and an Error keeps `message` and `stack` non-enumerable, so those
+	// entries render as an empty `error: {}` and hide the actual failure. Serializing `error`
+	// the same way makes both spellings print the message and stack.
+	serializers: {
+		error: pino.stdSerializers.err,
+	},
 	transport: {
 		target: 'pino-pretty',
 		options: {


### PR DESCRIPTION
Any error thrown during startup was logged as error: {}. Pino only applies its error serializer to the err key, and message/stack on an Error are non-enumerable, so logger.error({ error }, ...) drops exactly the information you need.

In my case a missing JWT_EXPIRES_IN produced nothing but Failed to start the server: error: {}. The API process exited on every boot while the frontend and all three workers kept running, so the container reported healthy and the login page loaded — but no request could succeed. Finding the cause required calling createServer() manually from a patched script inside the container.

Registering pino.stdSerializers.err for the error key fixes every call site using that spelling (14 in the current tree, including Failed to verify IMAP connection), and leaves err untouched. The redundant third argument on the startup log is dropped as well, since pino ignores it.

Verified against pino directly: without the serializer "error":{}, with it the full message and stack.